### PR TITLE
facilitate out of source builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ AM_CONDITIONAL([HAVE_CXX0X_CONSTEXPR],dnl
   [test x"$HAVE_CXX0X_CONSTEXPR" = x"yes"])[]dnl
 
 # implicitly set the Dune-flags everywhere
-AC_SUBST(AM_CPPFLAGS, $DUNE_CPPFLAGS)
+AC_SUBST(AM_CPPFLAGS, '$(DUNE_CPPFLAGS)  -I$(top_srcdir)')
 AC_SUBST(AM_LDFLAGS, $DUNE_LDFLAGS)
 LIBS="$DUNE_LIBS"
 

--- a/dune/porsol/common/Makefile.am
+++ b/dune/porsol/common/Makefile.am
@@ -17,7 +17,7 @@ libopmporsolcommon_la_SOURCES = \
 	LinearSolverISTL.cpp
 
 
-libopmporsolcommon_la_CPPFLAGS = $(DUNE_CPPFLAGS) $(OPM_BOOST_CPPFLAGS)
+libopmporsolcommon_la_CPPFLAGS = $(AM_CPPFLAGS) $(DUNE_CPPFLAGS) $(OPM_BOOST_CPPFLAGS)
 libopmporsolcommon_la_LDFLAGS  = $(DUNE_LDFLAGS) $(OPM_BOOST_LDFLAGS)
 
 include $(top_srcdir)/am/global-rules


### PR DESCRIPTION
1. Setting AM_CPPFLAGS to include $(top_srcdir) as include path
2. Use AM_CPPFLAGS when compiling.
