### PR TITLE
Make dune-porsol compile g++-4.7

### DIFF
--- a/dune/porsol/euler/EulerUpstream.hpp
+++ b/dune/porsol/euler/EulerUpstream.hpp
@@ -105,7 +105,6 @@ namespace Dune {
 	typedef typename GridInterface::CellIterator CIt;
 	typedef typename CIt::FaceIterator FIt;
 	typedef typename FIt::Vector Vector;
-        typedef ReservoirProperties RP;
 
 
 	template <class PressureSolution>

--- a/dune/porsol/euler/EulerUpstreamImplicit.hpp
+++ b/dune/porsol/euler/EulerUpstreamImplicit.hpp
@@ -107,7 +107,6 @@ namespace Dune {
 	// typedef typename GridInterface::CellIterator CIt;
 	// typedef typename CIt::FaceIterator FIt;
 	// typedef typename FIt::Vector Vector;
-     typedef ReservoirProperties RP;
 
 	template <class PressureSolution>
 	void smallTimeStep(std::vector<double>& saturation,

--- a/dune/porsol/euler/ImplicitCapillarity.hpp
+++ b/dune/porsol/euler/ImplicitCapillarity.hpp
@@ -102,7 +102,6 @@ namespace Dune {
 	typedef typename GridInterface::CellIterator CIt;
 	typedef typename CIt::FaceIterator FIt;
 	typedef typename FIt::Vector Vector;
-        typedef ReservoirProperties RP;
 
         mutable PressureSolver psolver_;
 


### PR DESCRIPTION
Somehow the compiler was confused by a typedef with the same name as one of the template parameters used in the function definition. While this seems to be a bug in gcc, I could be circumvented by removing the typedefs. dune-porsol now compiles with g++ version 4.7.

BTW:: Finally these are really just the changes needed for g++ 4.7
