### PR TITLE
Improve handling of isolated nodes

### DIFF
--- a/dune/porsol/mimetic/IncompFlowSolverHybrid.hpp
+++ b/dune/porsol/mimetic/IncompFlowSolverHybrid.hpp
@@ -1483,6 +1483,7 @@ namespace Dune {
                 criterion.setDefaultValuesAnisotropic(3, 2);
 #endif
                 criterion.setProlongationDampingFactor(prolong_factor);
+                criterion.setBeta(1e-10);
                 precond_.reset(new Precond(*opS_, criterion, smootherArgs,
 				           1, smooth_steps, smooth_steps));
             }
@@ -1545,6 +1546,7 @@ namespace Dune {
                 criterion.setDefaultValuesAnisotropic(3, 2);
 #endif
                 criterion.setProlongationDampingFactor(prolong_factor);
+                criterion.setBeta(1e-10);
                 precond_.reset(new Precond(*opS_, criterion, smootherArgs, 2, smooth_steps, smooth_steps));
             }
             // Construct solver for system of linear equations.


### PR DESCRIPTION
Set beta to a very low value. The beta threshold is used to identify
isolated vertices. Having to many of these breaks the coarse grid
approximation property. An alternative would be to use skipIsolated in the
AMG criterion, but there is a bug in the dune-istl release.

Using the above approach has nearly the same effect and makes upscale_perm a
lot faster for the problems provided by Lars.
