### PR TITLE
Change use of Boost.Filesystem

### DIFF
--- a/dune/porsol/common/setupGridAndProps.hpp
+++ b/dune/porsol/common/setupGridAndProps.hpp
@@ -85,7 +85,8 @@ namespace Dune
             // Save EGRID file in case we are writing ECL output.
             if (param.getDefault("output_ecl", false)) {
                 boost::filesystem::path ecl_path(ecl_file);
-                parser.saveEGRID(ecl_path.stem().string() + ".FEGRID");
+                ecl_path.replace_extension(".FEGRID");
+                parser.saveEGRID(ecl_path.string());
             }
             double perm_threshold_md = param.getDefault("perm_threshold_md", 0.0);
 	    double perm_threshold = Opm::unit::convert::from(perm_threshold_md, Opm::prefix::milli*Opm::unit::darcy);


### PR DESCRIPTION
The current version should compile and work with v2 and v3 of Boost.Filesystem.
Notes:
- There is a bug in replace_extension() for v3, one must include the '.' in
  the extension. Worked around by using ".FEGRID" (which includes the dot).
- v2 is no longer available since Boost 1.48 and cannot be used.
- v3 is available starting from 1.44, and default from 1.46.
- We do not need to define the BOOST_FILESYSTEM_VERSION macro, since the
  syntax chosen works with both v2 and v2.
- In the future, we may need to use v3 features, and support Boost 1.44 and
  1.45 by defining the version macro. This will drop support for 1.43 and lower.
