### PR TITLE
fix some fallout of the Dune->Opm conversion

### DIFF
--- a/opm/porsol/euler/EulerUpstreamResidual.hpp
+++ b/opm/porsol/euler/EulerUpstreamResidual.hpp
@@ -60,7 +60,7 @@ namespace Opm {
     {
     public:
         template <class S, class P>
-        friend class EulerUpstreamResidualDetails::UpdateForCell;
+        friend struct EulerUpstreamResidualDetails::UpdateForCell;
 	typedef typename GridInterface::CellIterator CIt;
 	typedef typename CIt::FaceIterator FIt;
 	typedef typename FIt::Vector Vector;

--- a/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
+++ b/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
@@ -1434,7 +1434,7 @@ namespace Opm {
 #endif
 
 #if SMOOTHER_BGS
-      typedef SeqOverlappingSchwarz<Matrix,Vector,Dune::MultiplicativeSchwarzMode> Smoother;
+      typedef Dune::SeqOverlappingSchwarz<Matrix,Vector,Dune::MultiplicativeSchwarzMode> Smoother;
 #else
 #if SMOOTHER_ILU
         typedef Dune::SeqILU0<Matrix,Vector,Vector>        Smoother;


### PR DESCRIPTION
the class->struct change avoids a CLang warning, the second change is
a class that is not tested within opm-porsol but required for opm-upscaling.
