### PR TITLE
Add support for AMG improvements when using inofficial 2.2 DUNE release with CMake support

### DIFF
--- a/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
+++ b/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
@@ -684,7 +684,8 @@ namespace Opm {
                 solveLinearSystemFastAMG(residual_tolerance, linsolver_verbosity, 
                              linsolver_maxit, prolongate_factor, same_matrix,smooth_steps);
 #else
-                #warning "Fast AMG is not available; falling back to CG preconditioned with the normal one"
+                if(linsolver_verbosity)
+                    std::cerr<<"Fast AMG is not available; falling back to CG preconditioned with the normal one."<<std::endl;
                 solveLinearSystemAMG(residual_tolerance, linsolver_verbosity, 
 				     linsolver_maxit, prolongate_factor, same_matrix, smooth_steps);
 #endif
@@ -1552,9 +1553,6 @@ namespace Opm {
 		
                 // Construct preconditioner.
                 typedef Dune::Amg::AggregationCriterion<Dune::Amg::SymmetricMatrixDependency<Matrix,CouplingMetric> > CriterionBase;
-#if !SYMMETRIC
-#warn "Only symmetric matrices are supported currently. Computing anyway..."
-#endif
 
                 typedef Dune::Amg::CoarsenCriterion<CriterionBase> Criterion;
                 Criterion criterion;


### PR DESCRIPTION
In the inofficial 2.2 DUNE release with CMake support I have backported some new ISTL features from the trunk. Namely, a faster hierarchy setup of the AMG and a new AMG variant that better utilizes the available memory bandwidth for a faster solve phase.

These commits make the new fast AMG version available as an additional solver. If it is not available, we simply fall-back to the standard AMG.

I will leave it to the release managers, whether to incorporate this into the release or not.

Comments are very welcome.
