### PR TITLE
error: 'constexpr' does not name a type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,10 @@ opm_sources (${project})
 
 ### --- begin opm-porsol specific --- ###
 if (NOT HAVE_CONSTEXPR)
-	opm_disable_source (examples examples/co2_sim_test.cpp)
+	opm_disable_source (examples
+		examples/co2_blackoil_pvt.cpp
+		examples/co2_sim_test.cpp
+		)
 endif (NOT HAVE_CONSTEXPR)
 ### --- end opm-porsol specific --- ###
 


### PR DESCRIPTION
When building opm-porsol (release/2013.03 branch) on rhel 5 I get the following error:

/private/laods/opm/RH5/realization_cmake/only_cmake/opm-porsol/opm/porsol/blackoil/co2fluid/opm/material/constants.hh:46: error: 'constexpr' does not name a type

Can this be a compilator error? I use gcc 4.1.2.
