### PR TITLE
Look for keyword 'ROCKTYPE' if 'SATNUM' is not found

### DIFF
--- a/opm/porsol/common/ReservoirPropertyCommon_impl.hpp
+++ b/opm/porsol/common/ReservoirPropertyCommon_impl.hpp
@@ -674,8 +674,8 @@ namespace Opm
                 cell_to_rock_[c] = satnum[global_cell[c]] - 1;
             }
         }
-	else if (parser.hasField("ROCKTYPE")) {
-	    Opm::EclipseGridInspector insp(parser);
+        else if (parser.hasField("ROCKTYPE")) {
+            Opm::EclipseGridInspector insp(parser);
             std::tr1::array<int, 3> dims = insp.gridSize();
             int num_global_cells = dims[0]*dims[1]*dims[2];
             const std::vector<int>& satnum = parser.getIntegerValue("ROCKTYPE");
@@ -688,7 +688,7 @@ namespace Opm
                 // Note: ROCKTYPE is FORTRANish, ranging from 1 to n, therefore we subtract one.
                 cell_to_rock_[c] = satnum[global_cell[c]] - 1;
             }
-	}
+        }
     }
 
 


### PR DESCRIPTION
Some eclipse grid files include keyword 'ROCKTYPE' instead of 'SATNUM'. This is for instance the case for some grids exported from SBED. 

When using the upscaling application `steadystate_test_implicit`, not checking for 'ROCKTYPE' can be problematic since the routine now assumes that only one stone type is present and the first stone file will be used for all cells. 

I'm not sure if this problem is present elsewhere in the source code. At least this resolved my issue when running `steadystate_test_implicit`. For the applications `upscale_relperm` and `upscale_relpermvisc` this  check is already implemented. 
