### PR TITLE
Disable build kluge that is no longer pertinent

### DIFF
--- a/examples/aniso_implicitcap_test.cpp
+++ b/examples/aniso_implicitcap_test.cpp
@@ -41,8 +41,6 @@
 #include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include "SimulatorTester.hpp"
 #include "SimulatorTesterFlexibleBC.hpp"
 #include <opm/porsol/common/SimulatorTraits.hpp>

--- a/examples/aniso_simulator_test.cpp
+++ b/examples/aniso_simulator_test.cpp
@@ -41,8 +41,6 @@
 #include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include "SimulatorTester.hpp"
 #include "SimulatorTesterFlexibleBC.hpp"
 #include <opm/porsol/common/SimulatorTraits.hpp>

--- a/examples/co2_blackoil_pvt.cpp
+++ b/examples/co2_blackoil_pvt.cpp
@@ -21,7 +21,6 @@
 
 #include "config.h"
 
-#include <opm/core/utility/have_boost_redef.hpp>
 #include <opm/core/utility/StopWatch.hpp>
 #include <opm/porsol/blackoil/co2fluid/BlackoilCo2PVT.hpp>
 

--- a/examples/implicitcap_test.cpp
+++ b/examples/implicitcap_test.cpp
@@ -41,8 +41,6 @@
 #include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include "SimulatorTester.hpp"
 #include "SimulatorTesterFlexibleBC.hpp"
 #include <opm/porsol/common/SimulatorTraits.hpp>

--- a/examples/known_answer_test.cpp
+++ b/examples/known_answer_test.cpp
@@ -39,8 +39,6 @@
 #include <config.h>
 #endif
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <algorithm>
 #include <iostream>
 #include <iomanip>

--- a/examples/mimetic_aniso_solver_test.cpp
+++ b/examples/mimetic_aniso_solver_test.cpp
@@ -37,8 +37,6 @@
 #include <config.h>
 #endif
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <algorithm>
 #include <iostream>
 #include <iomanip>

--- a/examples/mimetic_periodic_test.cpp
+++ b/examples/mimetic_periodic_test.cpp
@@ -35,8 +35,6 @@
 
 #include "config.h"
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <iostream>
 
 #include <boost/array.hpp>

--- a/examples/mimetic_solver_test.cpp
+++ b/examples/mimetic_solver_test.cpp
@@ -37,8 +37,6 @@
 #include <config.h>
 #endif
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <algorithm>
 #include <iostream>
 #include <iomanip>

--- a/examples/sim_blackoil_impes.cpp
+++ b/examples/sim_blackoil_impes.cpp
@@ -21,8 +21,6 @@
 
 #include "config.h"
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <opm/porsol/blackoil/fluid/BlackoilPVT.hpp>
 #include <opm/porsol/blackoil/BlackoilFluid.hpp>
 

--- a/examples/sim_co2_impes.cpp
+++ b/examples/sim_co2_impes.cpp
@@ -21,8 +21,6 @@
 
 #include "config.h"
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
 #include <opm/porsol/blackoil/BlackoilSimulator.hpp>
 #include <dune/common/mpihelper.hh>

--- a/examples/sim_steadystate_explicit.cpp
+++ b/examples/sim_steadystate_explicit.cpp
@@ -26,8 +26,6 @@
 #include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include "SimulatorTester.hpp"
 #include "SimulatorTesterFlexibleBC.hpp"
 #include <opm/porsol/common/SimulatorTraits.hpp>

--- a/examples/sim_steadystate_implicit.cpp
+++ b/examples/sim_steadystate_implicit.cpp
@@ -25,8 +25,6 @@
 #include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include "SimulatorTester.hpp"
 #include "SimulatorTesterFlexibleBC.hpp"
 #include <opm/porsol/euler/EulerUpstreamImplicit.hpp>

--- a/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
+++ b/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
@@ -19,8 +19,6 @@
 
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include "BlackoilPVT.hpp"
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
 #include <opm/core/utility/Units.hpp>

--- a/opm/porsol/blackoil/fluid/MiscibilityLiveOil.cpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityLiveOil.cpp
@@ -30,8 +30,6 @@
 
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <algorithm>
 #include "MiscibilityLiveOil.hpp"
 #include <opm/core/utility/ErrorMacros.hpp>

--- a/opm/porsol/common/LinearSolverISTL.cpp
+++ b/opm/porsol/common/LinearSolverISTL.cpp
@@ -21,8 +21,6 @@
 #include "config.h"
 #endif
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include "LinearSolverISTL.hpp"
 
 

--- a/tests/common/boundaryconditions_test.cpp
+++ b/tests/common/boundaryconditions_test.cpp
@@ -34,8 +34,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #if defined(HAVE_DYNAMIC_BOOST_TEST)
 #define BOOST_TEST_DYN_LINK
 #endif

--- a/tests/common/matrix_test.cpp
+++ b/tests/common/matrix_test.cpp
@@ -19,8 +19,6 @@
 
 #include "config.h"
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #if defined(HAVE_DYNAMIC_BOOST_TEST)
 #define BOOST_TEST_DYN_LINK
 #endif

--- a/tests/not-unit/appleyard/appleyard_test.cpp
+++ b/tests/not-unit/appleyard/appleyard_test.cpp
@@ -19,8 +19,6 @@
 
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/porsol/appleyard/Appleyard.hpp>
 

--- a/tests/not-unit/blackoil/bo_fluid_p_and_z_deps.cpp
+++ b/tests/not-unit/blackoil/bo_fluid_p_and_z_deps.cpp
@@ -20,8 +20,6 @@
 
 #include "config.h"
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <opm/porsol/blackoil/fluid/BlackoilPVT.hpp>
 #include <opm/porsol/blackoil/BlackoilFluid.hpp>
 

--- a/tests/not-unit/blackoil/bo_fluid_pressuredeps.cpp
+++ b/tests/not-unit/blackoil/bo_fluid_pressuredeps.cpp
@@ -19,8 +19,6 @@
 
 #include "config.h"
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <opm/porsol/blackoil/fluid/BlackoilPVT.hpp>
 #include <opm/porsol/blackoil/BlackoilFluid.hpp>
 

--- a/tests/not-unit/blackoil/bo_fluid_test.cpp
+++ b/tests/not-unit/blackoil/bo_fluid_test.cpp
@@ -19,8 +19,6 @@
 
 #include "config.h"
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <opm/porsol/blackoil/fluid/FluidMatrixInteractionBlackoil.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <dune/common/fvector.hh>

--- a/tests/not-unit/blackoil/bo_well_test.cpp
+++ b/tests/not-unit/blackoil/bo_well_test.cpp
@@ -19,8 +19,6 @@
 
 #include "config.h"
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <iostream>
 #include <opm/core/utility/Units.hpp>
 #include <opm/porsol/blackoil/BlackoilWells.hpp>

--- a/tests/not-unit/common/gie_test.cpp
+++ b/tests/not-unit/common/gie_test.cpp
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <iostream>
 
 #include <boost/static_assert.hpp>

--- a/tests/not-unit/common/periodic_test.cpp
+++ b/tests/not-unit/common/periodic_test.cpp
@@ -35,8 +35,6 @@
 
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include "../PeriodicHelpers.hpp"
 #include <opm/porsol/common/BoundaryConditions.hpp>
 #include <opm/porsol/common/GridInterfaceEuler.hpp>

--- a/tests/not-unit/common/rockjfunc_test.cpp
+++ b/tests/not-unit/common/rockjfunc_test.cpp
@@ -35,8 +35,6 @@
 
 #include "config.h"
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include "../RockJfunc.hpp"
 #include <opm/porsol/common/Matrix.hpp>
 #include <opm/core/utility/Units.hpp>

--- a/tests/not-unit/euler/euler_upstream_test.cpp
+++ b/tests/not-unit/euler/euler_upstream_test.cpp
@@ -39,8 +39,6 @@
 #include "config.h"
 #endif
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include "../EulerSolverTester.hpp"
 #include <dune/common/mpihelper.hh>
 

--- a/tests/not-unit/mimetic/mimetic_ipeval_test.cpp
+++ b/tests/not-unit/mimetic/mimetic_ipeval_test.cpp
@@ -36,8 +36,6 @@
 
 #include "config.h"
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <algorithm>
 #include <iostream>
 


### PR DESCRIPTION
The <have_boost_redef.hpp> header was introduced (commit
OPM/opm-core@82369f9) as a work-around for a particular interaction
in the Autotools-based setup of OPM-Core and the Dune core modules.
Notably, Dune's "Enable" trick for Boost failed on some older
Autoconf systems.  Now that we're using CMake, however, that kluge
is no longer needed because OPM-Core always

  #define HAVE_BOOST 1

i.e., as an explict true/false value.

Therefore, we need no longer include <have_boost_redef.hpp> .  The
header will be removed at a later time.
