### PR TITLE
Changed std::tr1 occurences to boost.

### DIFF
--- a/examples/mimetic_aniso_solver_test.cpp
+++ b/examples/mimetic_aniso_solver_test.cpp
@@ -115,7 +115,7 @@ void test_evaluator(const Interface& g)
 
 void build_grid(const Opm::EclipseGridParser& parser,
                 const double z_tol, Dune::CpGrid& grid,
-                std::tr1::array<int,3>& cartDims)
+                boost::array<int,3>& cartDims)
 {
     Opm::EclipseGridInspector insp(parser);
 
@@ -224,7 +224,7 @@ int main(int argc, char** argv)
 
     Opm::EclipseGridParser parser(param.get<std::string>("filename"));
     double z_tol = param.getDefault<double>("z_tolerance", 0.0);
-    std::tr1::array<int,3> cartDims;
+    boost::array<int,3> cartDims;
     build_grid(parser, z_tol, grid, cartDims);
 
     // Make the grid interface

--- a/opm/porsol/blackoil/ComponentTransport.hpp
+++ b/opm/porsol/blackoil/ComponentTransport.hpp
@@ -20,7 +20,7 @@
 #ifndef OPM_COMPONENTTRANSPORT_HEADER_INCLUDED
 #define OPM_COMPONENTTRANSPORT_HEADER_INCLUDED
 
-#include <tr1/array>
+#include <boost/array.hpp>
 #include <vector>
 #include <opm/porsol/blackoil/fluid/BlackoilDefs.hpp>
 #include <opm/porsol/blackoil/BlackoilFluid.hpp>

--- a/opm/porsol/blackoil/fluid/MiscibilityProps.hpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityProps.hpp
@@ -37,7 +37,7 @@
 
 #include "BlackoilDefs.hpp"
 #include <vector>
-#include <tr1/array>
+#include <boost/array.hpp>
 
 namespace Opm
 {

--- a/opm/porsol/common/ReservoirPropertyCommon_impl.hpp
+++ b/opm/porsol/common/ReservoirPropertyCommon_impl.hpp
@@ -574,7 +574,7 @@ namespace Opm
 
         if (parser.hasField("PORO")) {
 	    Opm::EclipseGridInspector insp(parser);
-            std::tr1::array<int, 3> dims = insp.gridSize();
+            boost::array<int, 3> dims = insp.gridSize();
             int num_global_cells = dims[0]*dims[1]*dims[2];
             const std::vector<double>& poro = parser.getFloatingPointValue("PORO");
             if (int(poro.size()) != num_global_cells) {
@@ -597,7 +597,7 @@ namespace Opm
                                                                             double perm_threshold)
     {
 	Opm::EclipseGridInspector insp(parser);
-        std::tr1::array<int, 3> dims = insp.gridSize();
+        boost::array<int, 3> dims = insp.gridSize();
         int num_global_cells = dims[0]*dims[1]*dims[2];
         ASSERT (num_global_cells > 0);
 
@@ -661,7 +661,7 @@ namespace Opm
 
         if (parser.hasField("SATNUM")) {
 	    Opm::EclipseGridInspector insp(parser);
-            std::tr1::array<int, 3> dims = insp.gridSize();
+            boost::array<int, 3> dims = insp.gridSize();
             int num_global_cells = dims[0]*dims[1]*dims[2];
             const std::vector<int>& satnum = parser.getIntegerValue("SATNUM");
             if (int(satnum.size()) != num_global_cells) {
@@ -676,7 +676,7 @@ namespace Opm
         }
         else if (parser.hasField("ROCKTYPE")) {
             Opm::EclipseGridInspector insp(parser);
-            std::tr1::array<int, 3> dims = insp.gridSize();
+            boost::array<int, 3> dims = insp.gridSize();
             int num_global_cells = dims[0]*dims[1]*dims[2];
             const std::vector<int>& satnum = parser.getIntegerValue("ROCKTYPE");
             if (int(satnum.size()) != num_global_cells) {

--- a/opm/porsol/common/Rock_impl.hpp
+++ b/opm/porsol/common/Rock_impl.hpp
@@ -135,7 +135,7 @@ namespace Opm
                                        double perm_threshold)
     {
 	Opm::EclipseGridInspector insp(parser);
-        std::tr1::array<int, 3> dims = insp.gridSize();
+        boost::array<int, 3> dims = insp.gridSize();
         int num_global_cells = dims[0]*dims[1]*dims[2];
         ASSERT (num_global_cells > 0);
 

--- a/opm/porsol/euler/EulerUpstream.hpp
+++ b/opm/porsol/euler/EulerUpstream.hpp
@@ -38,7 +38,7 @@ along with OpenRS.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <opm/porsol/euler/EulerUpstreamResidual.hpp>
 
-#include <tr1/unordered_map>
+#include <boost/unordered_map.hpp>
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/core/utility/SparseVector.hpp>

--- a/opm/porsol/euler/EulerUpstreamImplicit.hpp
+++ b/opm/porsol/euler/EulerUpstreamImplicit.hpp
@@ -36,7 +36,7 @@ along with OpenRS.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef OPENRS_EULERUPSTREAMIMPLICIT_HEADER
 #define OPENRS_EULERUPSTREAMIMPLICIT_HEADER
 
-#include <tr1/unordered_map>
+#include <boost/unordered_map.hpp>
 
 #include <opm/core/utility/SparseVector.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>

--- a/opm/porsol/euler/EulerUpstreamResidual.hpp
+++ b/opm/porsol/euler/EulerUpstreamResidual.hpp
@@ -38,7 +38,7 @@
 
 
 
-#include <tr1/unordered_map>
+#include <boost/unordered_map.hpp>
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/core/utility/SparseVector.hpp>

--- a/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
+++ b/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
@@ -47,7 +47,7 @@
 #include <utility>
 #include <vector>
 
-#include <tr1/unordered_map>
+#include <boost/unordered_map.hpp>
 
 #include <boost/bind.hpp>
 #include <boost/scoped_ptr.hpp>
@@ -901,7 +901,7 @@ namespace Opm {
 
     private:
         typedef std::pair<int,int>                 DofID;
-        typedef std::tr1::unordered_map<int,DofID> BdryIdMapType;
+        typedef boost::unordered_map<int,DofID> BdryIdMapType;
         typedef BdryIdMapType::const_iterator      BdryIdMapIterator;
 
         const GridInterface* pgrid_;

--- a/opm/porsol/mimetic/TpfaCompressible.hpp
+++ b/opm/porsol/mimetic/TpfaCompressible.hpp
@@ -28,7 +28,7 @@
 #include <opm/core/utility/SparseTable.hpp>
 #include <opm/porsol/common/LinearSolverISTL.hpp>
 
-#include <tr1/array>
+#include <boost/array.hpp>
 
 namespace Opm
 {


### PR DESCRIPTION
std::tr1 might not be supported by all compilers and will eventually
be dropped by others. Using boost instead makes this more
portable.

Pull requests for the other modules will follow shortly.
