### PR TITLE
make it compile on what will become DUNE 2.3

### DIFF
--- a/examples/known_answer_test.cpp
+++ b/examples/known_answer_test.cpp
@@ -283,7 +283,7 @@ void test_flowsolver(const GI& g, const RI& r, double tol, int kind)
     vtkwriter.addCellData(cell_velocity_flat, "velocity", GI::GridType::dimension);
     vtkwriter.addCellData(cell_pressure, "pressure");
     vtkwriter.write("testsolution-" + boost::lexical_cast<std::string>(0),
-                    Dune::VTKOptions::ascii);
+                    Dune::VTK::ascii);
 }
 
 

--- a/examples/mimetic_solver_test.cpp
+++ b/examples/mimetic_solver_test.cpp
@@ -133,7 +133,7 @@ void test_flowsolver(const GI& g, const RI& r)
     vtkwriter.addCellData(cell_velocity_flat, "velocity", dim);
     vtkwriter.addCellData(cell_pressure, "pressure");
     vtkwriter.write("testsolution-" + boost::lexical_cast<std::string>(0),
-                    Dune::VTKOptions::ascii);
+                    Dune::VTK::ascii);
 #else    
     solver.printSystem("system");
     typedef typename FlowSolver::SolutionType FlowSolution;

--- a/opm/porsol/blackoil/BlackoilSimulator.hpp
+++ b/opm/porsol/blackoil/BlackoilSimulator.hpp
@@ -497,7 +497,7 @@ output(const Grid& grid,
     vtkwriter.addCellData(mass_frac_flat, "massFrac", Fluid::numComponents);
     vtkwriter.addCellData(totflvol_dens, "total fl. vol.");
     vtkwriter.write(filebase + '-' + boost::lexical_cast<std::string>(step),
-                    Dune::VTKOptions::ascii);
+                    Dune::VTK::ascii);
 
     // Dump data for Matlab.
     std::vector<double> zv[Fluid::numComponents];

--- a/opm/porsol/common/SimulatorUtilities.hpp
+++ b/opm/porsol/common/SimulatorUtilities.hpp
@@ -276,7 +276,7 @@ namespace Opm
         vtkwriter.addCellData(cell_velocity_flat, "velocity", Vec::dimension);
         vtkwriter.addCellData(water_velocity_flat, "phase velocity [water]", Vec::dimension);
         vtkwriter.addCellData(oil_velocity_flat, "phase velocity [oil]", Vec::dimension);
-        vtkwriter.write(filename, Dune::VTKOptions::ascii);
+        vtkwriter.write(filename, Dune::VTK::ascii);
     }
 
 


### PR DESCRIPTION
'VTKOptions' has been renamed to 'VTK' since circa DUNE 2.0. With 2.3 it is going to be removed. Using VTKOptions did not produce a deprecation warning because it is an enum, though.
