### PR TITLE
Module mode CMake probe for opm-material

### DIFF
--- a/cmake/Modules/Findopm-material.cmake
+++ b/cmake/Modules/Findopm-material.cmake
@@ -1,0 +1,44 @@
+# - Find OPM materials library
+#
+# Defines the following variables:
+#   opm-material_INCLUDE_DIRS    Directory of header files
+#   opm-material_LIBRARIES       Directory of shared object files
+#   opm-material_DEFINITIONS     Defines that must be set to compile
+#   opm-material_CONFIG_VARS     List of defines that should be in config.h
+#   HAVE_OPM_MATERIAL            Binary value to use in config.h
+
+# Copyright (C) 2013 Uni Research AS
+# This code is licensed under The GNU General Public License v3.0
+
+# use the generic find routine
+include (OpmPackage)
+find_opm_package (
+  # module name
+  "opm-material"
+
+  # dependencies
+  "C99;
+  CXX11Features
+  "
+  # header to search for
+  "opm/material/constants.hh"
+
+  # library to search for
+  ""
+
+  # defines to be added to compilations
+  ""
+
+  # test program
+"#include <opm/material/constants.hh>
+int main (void) {
+  double c = Opm::Constants<double>::c;
+  return 0;  
+}
+"
+  # config variables
+  "HAVE_MPI;
+  HAVE_VALGRIND
+  ")
+include (UseDynamicBoost)
+#debug_find_vars ("opm-material")


### PR DESCRIPTION
Apparently, since opm/opm-porsol#54 a bug in OpmFind has been uncovered; you cannot find a opm-material unless you specify `-Dopm-material_DIR=`, or there is a `Findopm-material.cmake` module for it. I haven't spent time tracking this one down. This changeset pulls a patch out of opm/opm-porsol#63 which I think will fix it; however, I haven't tested it. (If opm-porsol built for you before, it should also do so after this changeset)

@alfbr
