### PR TITLE
Remove references to ALUGrid.

### DIFF
--- a/examples/known_answer_test.cpp
+++ b/examples/known_answer_test.cpp
@@ -47,12 +47,6 @@
 #include <dune/common/mpihelper.hh>
 #include <opm/core/utility/Units.hpp>
 
-// #if HAVE_ALUGRID
-// #include <dune/common/shared_ptr.hh>
-// #include <dune/grid/io/file/gmshreader.hh>
-// #include <dune/grid/alugrid.hh>
-// #endif
-
 #include <opm/porsol/common/SimulatorUtilities.hpp>
 #include <dune/grid/io/file/vtk/vtkwriter.hh>
 


### PR DESCRIPTION
ALUGrid currently causes build errors when combined with the CMake
roll-up request (PR OPM/opm-porsol#63).  Rather than blocking that PR
indefinitely, simply remove all references to the grid manager from
opm-porsol.  If needed, we can re-enable ALUGrid support at a later
time.
