### PR TITLE
adapt to the many OPM-material file renames

### DIFF
--- a/opm/porsol/blackoil/co2fluid/BlackoilCo2PVT.hpp
+++ b/opm/porsol/blackoil/co2fluid/BlackoilCo2PVT.hpp
@@ -25,11 +25,11 @@
 
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
 
-#include <opm/common/exceptions.hh>
-#include <opm/material/fluidsystems/brineco2fluidsystem.hh>
-#include <opm/material/fluidstates/compositionalfluidstate.hh>
-#include <opm/material/constraintsolvers/misciblemultiphasecomposition.hh>
-#include <opm/material/constraintsolvers/computefromreferencephase.hh>
+#include <opm/common/Exceptions.hpp>
+#include <opm/material/fluidsystems/BrineCO2FluidSystem.hpp>
+#include <opm/material/fluidstates/CompositionalFluidState.hpp>
+#include <opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp>
+#include <opm/material/constraintsolvers/ComputeFromReferencePhase.hpp>
 #include <opm/porsol/blackoil/co2fluid/benchmark3co2tables.hh>
 
 #include <opm/porsol/blackoil/fluid/MiscibilityProps.hpp>

--- a/opm/porsol/blackoil/co2fluid/benchmark3co2tables.hh
+++ b/opm/porsol/blackoil/co2fluid/benchmark3co2tables.hh
@@ -27,8 +27,8 @@
 #ifndef OPM_BENCHMARK3_CO2TABLES_HH
 #define OPM_BENCHMARK3_CO2TABLES_HH
 
-#include <opm/common/tabulated2dfunction.hh>
-#include <opm/common/statictabulated2dfunction.hh>
+#include <opm/common/Tabulated2dFunction.hpp>
+#include <opm/common/StaticTabulated2dFunction.hpp>
 
 #include <assert.h>
 


### PR DESCRIPTION
this renames the code which uses opm material to the new filnames of opm/opm-material#11. Please merge this PR atomically in conjunction with opm/opm-material#11 . Permission by the opm-material maintainer to do so is hereby granted.
