### PR TITLE
Restore object that is exclusively used in assert()s

### DIFF
--- a/opm/porsol/euler/EulerUpstreamImplicit_impl.hpp
+++ b/opm/porsol/euler/EulerUpstreamImplicit_impl.hpp
@@ -155,6 +155,11 @@ namespace Opm
         direclet_sat_.resize(0);
         direclet_hfaces_.resize(0);
 
+#if !defined(NDEBUG)
+        // Used in several assert()s below
+        const UnstructuredGrid& c_grid = *mygrid_.c_grid();
+#endif
+
         assert(periodic_cells_.size()==0);
         for (CIt c = g.cellbegin(); c != g.cellend(); ++c) {
             int cell0 = c->index();


### PR DESCRIPTION
Commit 0feae75 removed a seemingly unused object ('c_grid'), but this
object is used in a number of subsequent assert()s.  This commit
reintroduces that object, but only in debug mode (i.e., when 'NDEBUG'
is _not_ defined), and thus restores the debug build.

I don't know how this problem escaped my build testing, but I take full
responsibility and I do apologise for the build breakage.
