### PR TITLE
Remove unused "typedef"s

### DIFF
--- a/examples/mimetic_periodic_test.cpp
+++ b/examples/mimetic_periodic_test.cpp
@@ -59,7 +59,6 @@ try
 {
     typedef Opm::GridInterfaceEuler<Dune::CpGrid>                       GI;
     typedef GI  ::CellIterator                                     CI;
-    typedef CI  ::FaceIterator                                     FI;
     typedef Opm::BasicBoundaryConditions<true, false>                  BCs;
     typedef Opm::ReservoirPropertyCapillary<3>                    RI;
     typedef Opm::IncompFlowSolverHybrid<GI, RI, BCs,

--- a/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
+++ b/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
@@ -37,7 +37,6 @@ namespace Opm
 
     void BlackoilPVT::init(const Opm::EclipseGridParser& parser)
     {
-        typedef std::vector<std::vector<std::vector<double> > > table_t;
 	region_number_ = 0;
 
 	// Surface densities. Accounting for different orders in eclipse and our code.

--- a/opm/porsol/common/MatrixInverse.hpp
+++ b/opm/porsol/common/MatrixInverse.hpp
@@ -68,7 +68,6 @@ namespace Opm {
 	template <typename M>
 	M matprod(const M& m1, const M& m2)
 	{
-	    typedef typename M::value_type T;
 	    assert(m1.numCols() == m2.numRows());
 	    int num_contracting = m1.numCols();
 	    M m(m1.numRows(), m2.numCols(), (double*)0);


### PR DESCRIPTION
CLang and recent versions of GCC warn about unused typedefs.  This change-set simply removes the currently known instances of those.

This is a first step towards fixing the most egregious transgressions at http://www.opm-project.org/CDash/viewBuildError.php?type=1&buildid=6040.
