### PR TITLE
Bump version number and label.

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -5,8 +5,8 @@
 #Name of the module
 Module: opm-porsol
 Description: DUNE module containing porous media PDE solvers
-Version: 0.1
-Label: 2013.03
+Version: 1.0
+Label: 2013.10
 Maintainer: atgeirr@sintef.no
 #depending on 
 Depends: dune-common dune-grid dune-istl opm-core opm-material dune-cornerpoint


### PR DESCRIPTION
Version was 0.1, which was a bit misleading, since much of the
module contents is stable and unchanging. Changed to 1.0 to
reflect that.
