### PR TITLE
buildCellContrib(): Fix out-of-bounds indexing

### DIFF
--- a/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
+++ b/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
@@ -1784,15 +1784,17 @@ namespace Opm {
             matMulAdd_TN(Scalar(1.0), S, one, Scalar(0.0), Ft);
 
             L_[c]  = std::accumulate(Ft.data(), Ft.data() + Ft.numRows(), 0.0);
-            g_[c] -= std::accumulate(gflux.begin(), gflux.end(), Scalar(0.0));
+            g_[c] -= std::accumulate(gflux.begin(),
+                                     gflux.begin() + S.numRows(), Scalar(0.0));
 
             // rhs <- v_g - rhs (== v_g - h)
-            std::transform(gflux.begin(), gflux.end(), rhs.begin(),
+            std::transform(gflux.begin(), gflux.begin() + S.numRows(),
+                           rhs.begin(),
                            rhs.begin(),
                            std::minus<Scalar>());
 
             // rhs <- rhs + g_[c]/L_[c]*F
-            std::transform(rhs.begin(), rhs.end(), Ft.data(),
+            std::transform(rhs.begin(), rhs.begin() + S.numRows(), Ft.data(),
                            rhs.begin(),
                            axpby<Scalar>(Scalar(1.0), Scalar(g_[c] / L_[c])));
 


### PR DESCRIPTION
In the interest of reducing the number of allocations/deallocations, the `rhs` and `gflux` arrays are allocated once (of maximum size, `max_ncf_`) at the start of `assembleDynamic()`.  However, method `buildCellContrib()` implicitly assumes that `rhs` and `gflux` are sized according to the number of interfaces on a given cell.  This discrepancy leads to out-of-bounds indexing unless all cells have the same number of interfaces.

Rewrite `buildCellContrib()` to only inspect the appropriate number of array elements, i.e., those that correspond to the current number of cell interfaces.

This bug was present for a _long_ time.

Superb detective work by: @akva2.
