### PR TITLE
Fix out-of-bounds indexing in IncompFlowSolverHybrid

### DIFF
--- a/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
+++ b/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
@@ -1692,6 +1692,9 @@ namespace Opm {
                 const int c0 = cell[c->index()];
                 const int nf = cf.rowSize(c0);
 
+                pi   .resize(nf);
+                gflux.resize(nf);
+
                 // Extract contact pressures for cell 'c'.
                 for (int i = 0; i < nf; ++i) {
                     pi[i] = soln_[cf[c0][i]];


### PR DESCRIPTION
This change-set fixes two instances of semantic and actual out-of-bounds indexing in the system assembly and solution post-processing codes.  The issue was initially noticed and pointed out by @akva2 and @atgeirr subsequently found another instance of the same problem.

Basically, methods `assembleDynamic()` and `computePressureAndFluxes()` try to reduce the number of allocations and deallocations by preallocating work arrays of known maximum size.  However, some of these work arrays were subsequently used in a way that was inconsistent with always having that maximum size.  By explicitly resizing the work arrays, under the assumption that `std::vector<>::resize()` is an O(1) operation that does not affect the underlying memory if the block is large enough, we ensure that we're using the arrays in a consistent manner and don't incur out-of-bounds indexing.

This solves #91.
