### PR TITLE
Follow opm-material phase name changes

### DIFF
--- a/opm/porsol/blackoil/co2fluid/BlackoilCo2PVT.hpp
+++ b/opm/porsol/blackoil/co2fluid/BlackoilCo2PVT.hpp
@@ -105,8 +105,8 @@ private:
     };
     void computeState(SubState& ss, double zBrine, double zCO2, double pressure) const;
     enum {
-        wPhase = FluidSystem::lPhaseIdx,
-        nPhase = FluidSystem::gPhaseIdx,
+        wPhase = FluidSystem::liquidPhaseIdx,
+        nPhase = FluidSystem::gasPhaseIdx,
 
         wComp = FluidSystem::BrineIdx,
         nComp = FluidSystem::CO2Idx    


### PR DESCRIPTION
Commit OPM/opm-material@30c90734ce renamed, among other things

```
FluidSystem::gPhaseIdx -> FluidSystem::gasPhaseIdx
FluidSystem::lPhaseIdx -> FluidSystem::liquidPhaseIdx
```

Adapt to that change to fix the build.
