### PR TITLE
fix build: adapt the phase indices to the one used by opm-material

### DIFF
--- a/opm/porsol/blackoil/co2fluid/BlackoilCo2PVT.hpp
+++ b/opm/porsol/blackoil/co2fluid/BlackoilCo2PVT.hpp
@@ -105,8 +105,8 @@ private:
     };
     void computeState(SubState& ss, double zBrine, double zCO2, double pressure) const;
     enum {
-        wPhase = FluidSystem::lPhaseIdx,
-        nPhase = FluidSystem::gPhaseIdx,
+        wPhase = FluidSystem::liquidPhaseIdx,
+        nPhase = FluidSystem::gasPhaseIdx,
 
         wComp = FluidSystem::BrineIdx,
         nComp = FluidSystem::CO2Idx    


### PR DESCRIPTION
Since the {l,g}PhaseIdx -> {liquid,gas}PhaseIdx rename in opm-material
was done almost two weeks ago, I figure that nobody cared to update
opm-porsol and/or opm-material for that period...
