### PR TITLE
convert the module to the new parser

### DIFF
--- a/examples/co2_blackoil_pvt.cpp
+++ b/examples/co2_blackoil_pvt.cpp
@@ -33,10 +33,10 @@ try
     if (argc == 2) temperature = std::atof(argv[1]);
 
     Opm::BlackoilCo2PVT boPvt;
-    Opm::EclipseGridParser ep;
+    Opm::DeckConstPtr deck; // <- uninitalized pointer!
     Opm::time::StopWatch clock;
   clock.start();
-    boPvt.init(ep);
+    boPvt.init(deck);
 
     boPvt.generateBlackOilTables(temperature);
   clock.stop();

--- a/examples/known_answer_test.cpp
+++ b/examples/known_answer_test.cpp
@@ -59,8 +59,6 @@
 
 #include <dune/grid/yaspgrid.hh>
 #include <dune/grid/CpGrid.hpp>
-#include <opm/core/io/eclipse/EclipseGridParser.hpp>
-#include <opm/core/io/eclipse/EclipseGridInspector.hpp>
 
 #include <opm/porsol/common/fortran.hpp>
 #include <opm/porsol/common/blas_lapack.hpp>

--- a/examples/mimetic_solver_test.cpp
+++ b/examples/mimetic_solver_test.cpp
@@ -63,8 +63,6 @@
 
 #include <dune/grid/yaspgrid.hh>
 #include <dune/grid/CpGrid.hpp>
-#include <opm/core/io/eclipse/EclipseGridParser.hpp>
-#include <opm/core/io/eclipse/EclipseGridInspector.hpp>
 
 #include <opm/porsol/common/fortran.hpp>
 #include <opm/porsol/common/blas_lapack.hpp>

--- a/examples/sim_co2_impes.cpp
+++ b/examples/sim_co2_impes.cpp
@@ -21,7 +21,6 @@
 
 #include "config.h"
 
-#include <opm/core/io/eclipse/EclipseGridParser.hpp>
 #include <opm/porsol/blackoil/BlackoilSimulator.hpp>
 
 #include <dune/common/version.hh>

--- a/opm/porsol/blackoil/BlackoilFluid.hpp
+++ b/opm/porsol/blackoil/BlackoilFluid.hpp
@@ -55,6 +55,17 @@ namespace Opm
             surface_densities_[Gas] = dens[2];
         }
 
+        void init(Opm::DeckConstPtr deck)
+        {
+            fmi_params_.init(deck);
+            // FluidSystemBlackoil<>::init(parser);
+            pvt_.init(deck);
+            Opm::DeckRecordConstPtr densityRecord = deck->getKeyword("DENSITY")->getRecord(0);
+            surface_densities_[Oil] = densityRecord->getItem("OIL")->getSIDouble(0);
+            surface_densities_[Water] = densityRecord->getItem("WATER")->getSIDouble(0);
+            surface_densities_[Gas] = densityRecord->getItem("GAS")->getSIDouble(0);
+        }
+
         FluidState computeState(PhaseVec phase_pressure, CompVec z) const
         {
             FluidState state;

--- a/opm/porsol/blackoil/co2fluid/BlackoilCo2PVT.hpp
+++ b/opm/porsol/blackoil/co2fluid/BlackoilCo2PVT.hpp
@@ -20,10 +20,10 @@
 #ifndef OPM_BLACKOILCO2PVT_HEADER_INCLUDED
 #define OPM_BLACKOILCO2PVT_HEADER_INCLUDED
 
+#include <opm/core/io/eclipse/EclipseGridParser.hpp>
+
 #define OPM_DEPRECATED __attribute__((deprecated))
 #define OPM_DEPRECATED_MSG(msg) __attribute__((deprecated))
-
-#include <opm/core/io/eclipse/EclipseGridParser.hpp>
 
 #include <opm/material/fluidsystems/BrineCO2FluidSystem.hpp>
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
@@ -36,8 +36,11 @@
 #include <opm/porsol/blackoil/fluid/MiscibilityProps.hpp>
 #include <opm/porsol/blackoil/fluid/BlackoilDefs.hpp>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
 #include <string>
 #include <iostream>
+#include <fstream>
 
 
 namespace Opm
@@ -48,8 +51,9 @@ public:
         
     typedef Opm::FluidSystems::BrineCO2</*Scalar=*/double, Opm::Benchmark3::CO2Tables> FluidSystem;
     typedef Opm::CompositionalFluidState<double, FluidSystem> CompositionalFluidState;
-	
-	void init(const Opm::EclipseGridParser& ep);
+
+    void init(const Opm::EclipseGridParser& ep);
+	void init(Opm::DeckConstPtr deck);
 
     void generateBlackOilTables(double temperature);
 
@@ -117,6 +121,17 @@ private:
 // ------------ Method implementations --------------
 
 void BlackoilCo2PVT::init(const Opm::EclipseGridParser& ep)
+{
+        surfaceDensities_[Water]   = 1000.;
+        surfaceDensities_[Gas] = 2.0;
+        surfaceDensities_[Oil] = 1000.;
+
+    temperature_ = 300.;
+
+    brineCo2_.init();
+}
+
+void BlackoilCo2PVT::init(Opm::DeckConstPtr deck)
 {
 	surfaceDensities_[Water]   = 1000.;
 	surfaceDensities_[Gas] = 2.0;

--- a/opm/porsol/blackoil/fluid/BlackoilPVT.hpp
+++ b/opm/porsol/blackoil/fluid/BlackoilPVT.hpp
@@ -24,6 +24,7 @@
 #include "MiscibilityProps.hpp"
 #include "BlackoilDefs.hpp"
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <string>
 
@@ -33,7 +34,8 @@ namespace Opm
     class BlackoilPVT : public BlackoilDefs
     {
     public:
-	void init(const Opm::EclipseGridParser& ep);
+        void init(const Opm::EclipseGridParser& ep);
+        void init(Opm::DeckConstPtr deck);
 
         double getViscosity(double press,
                             const CompVec& surfvol,

--- a/opm/porsol/blackoil/fluid/FluidMatrixInteractionBlackoil.hpp
+++ b/opm/porsol/blackoil/fluid/FluidMatrixInteractionBlackoil.hpp
@@ -23,6 +23,9 @@
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
 #include <opm/core/utility/UniformTableLinear.hpp>
 #include <opm/core/utility/buildUniformMonotoneTable.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Utility/SgofTable.hpp>
+#include <opm/parser/eclipse/Utility/SwofTable.hpp>
 #include "BlackoilDefs.hpp"
 #include <iostream>
 #include <stdexcept>
@@ -56,6 +59,34 @@ public:
         const std::vector<double>& krg = sgof_table[0][1];
         const std::vector<double>& krog = sgof_table[0][2];
         const std::vector<double>& pcog = sgof_table[0][3];
+
+        // Create tables for krw, krow, krg and krog.
+        int samples = 200;
+        buildUniformMonotoneTable(sw, krw,  samples, krw_);
+        buildUniformMonotoneTable(sw, krow, samples, krow_);
+        buildUniformMonotoneTable(sg, krg,  samples, krg_);
+        buildUniformMonotoneTable(sg, krog, samples, krog_);
+        krocw_ = krow[0]; // At connate water -> ecl. SWOF
+
+        // Create tables for pcow and pcog.
+        buildUniformMonotoneTable(sw, pcow, samples, pcow_);
+        buildUniformMonotoneTable(sg, pcog, samples, pcog_);
+    }
+
+    void init(Opm::DeckConstPtr deck)
+    {
+        // Extract input data.
+        SwofTable swofTable(deck->getKeyword("SWOF"));
+        SgofTable sgofTable(deck->getKeyword("SGOF"));
+
+        const std::vector<double>& sw = swofTable.getSwColumn();
+        const std::vector<double>& krw = swofTable.getKrwColumn();
+        const std::vector<double>& krow = swofTable.getKrowColumn();
+        const std::vector<double>& pcow = swofTable.getPcowColumn();
+        const std::vector<double>& sg = sgofTable.getSgColumn();
+        const std::vector<double>& krg = sgofTable.getKrgColumn();
+        const std::vector<double>& krog = sgofTable.getKrogColumn();
+        const std::vector<double>& pcog = sgofTable.getPcogColumn();
 
         // Create tables for krw, krow, krg and krog.
         int samples = 200;

--- a/opm/porsol/blackoil/fluid/MiscibilityDead.cpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityDead.cpp
@@ -50,21 +50,69 @@ namespace Opm
     /// Constructor
     MiscibilityDead::MiscibilityDead(const table_t& pvd_table)
     {
-	const int region_number = 0;
-	if (pvd_table.size() != 1) {
-	    OPM_THROW(std::runtime_error, "More than one PVT-region");
-	}
+        const int region_number = 0;
+        if (pvd_table.size() != 1) {
+            OPM_THROW(std::runtime_error, "More than one PVT-region");
+        }
 
-	// Copy data
-	const int sz = pvd_table[region_number][0].size();
+        // Copy data
+        const int sz = pvd_table[region_number][0].size();
         std::vector<double> press(sz);
         std::vector<double> B_inv(sz);
         std::vector<double> visc(sz);
-	for (int i = 0; i < sz; ++i) {
+        for (int i = 0; i < sz; ++i) {
             press[i] = pvd_table[region_number][0][i];
             B_inv[i] = 1.0 / pvd_table[region_number][1][i];
             visc[i]  = pvd_table[region_number][2][i];
-	}
+        }
+        int samples = 1025;
+        buildUniformMonotoneTable(press, B_inv, samples, one_over_B_);
+        buildUniformMonotoneTable(press, visc, samples, viscosity_);
+
+        // Dumping the created tables.
+//         static int count = 0;
+//         std::ofstream os((std::string("dump-") + boost::lexical_cast<std::string>(count++)).c_str());
+//         os.precision(15);
+//         os << "1/B\n\n" << one_over_B_
+//            << "\n\nvisc\n\n" << viscosity_ << std::endl;
+    }
+
+    /// Constructor
+    MiscibilityDead::MiscibilityDead(const Opm::PvdgTable& pvdgTable)
+    {
+        // Copy data
+        std::vector<double> press(pvdgTable.getPressureColumn());
+        std::vector<double> B_inv(pvdgTable.getFormationFactorColumn());
+        std::vector<double> visc(pvdgTable.getViscosityColumn());
+
+        const int sz = B_inv.size();
+        for (int i = 0; i < sz; ++i) {
+            B_inv[i] = 1.0 / B_inv[i];
+        }
+        int samples = 1025;
+        buildUniformMonotoneTable(press, B_inv, samples, one_over_B_);
+        buildUniformMonotoneTable(press, visc, samples, viscosity_);
+
+        // Dumping the created tables.
+//         static int count = 0;
+//         std::ofstream os((std::string("dump-") + boost::lexical_cast<std::string>(count++)).c_str());
+//         os.precision(15);
+//         os << "1/B\n\n" << one_over_B_
+//            << "\n\nvisc\n\n" << viscosity_ << std::endl;
+    }
+
+    /// Constructor
+    MiscibilityDead::MiscibilityDead(const Opm::PvdoTable& pvdoTable)
+    {
+        // Copy data
+        std::vector<double> press(pvdoTable.getPressureColumn());
+        std::vector<double> B_inv(pvdoTable.getFormationFactorColumn());
+        std::vector<double> visc(pvdoTable.getViscosityColumn());
+
+        const int sz = B_inv.size();
+        for (int i = 0; i < sz; ++i) {
+            B_inv[i] = 1.0 / B_inv[i];
+        }
         int samples = 1025;
         buildUniformMonotoneTable(press, B_inv, samples, one_over_B_);
         buildUniformMonotoneTable(press, visc, samples, viscosity_);

--- a/opm/porsol/blackoil/fluid/MiscibilityDead.hpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityDead.hpp
@@ -37,15 +37,19 @@
 
 #include "MiscibilityProps.hpp"
 #include <opm/core/utility/UniformTableLinear.hpp>
+#include <opm/parser/eclipse/Utility/PvdoTable.hpp>
+#include <opm/parser/eclipse/Utility/PvdgTable.hpp>
 
 namespace Opm
 {
     class MiscibilityDead : public MiscibilityProps
     {
     public:
-	typedef std::vector<std::vector<std::vector<double> > > table_t;
+    typedef std::vector<std::vector<std::vector<double> > > table_t;
+    MiscibilityDead(const table_t& pvd_table);
 
-	MiscibilityDead(const table_t& pvd_table);
+        MiscibilityDead(const PvdoTable& pvdoTable);
+        MiscibilityDead(const PvdgTable& pvdgTable);
 	virtual ~MiscibilityDead();
 
         virtual double getViscosity(int region, double press, const surfvol_t& surfvol) const;

--- a/opm/porsol/blackoil/fluid/MiscibilityLiveGas.hpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityLiveGas.hpp
@@ -36,6 +36,7 @@
      */
 
 #include "MiscibilityProps.hpp"
+#include <opm/parser/eclipse/Utility/PvtgTable.hpp>
 
 namespace Opm
 {
@@ -44,7 +45,8 @@ namespace Opm
     public:
 	typedef std::vector<std::vector<std::vector<double> > > table_t;
 
-	MiscibilityLiveGas(const table_t& pvto);
+    MiscibilityLiveGas(const table_t& pvto);
+    MiscibilityLiveGas(const Opm::PvtgTable& pvtgTable);
 	virtual ~MiscibilityLiveGas();
 
         virtual double getViscosity(int region, double press, const surfvol_t& surfvol) const;

--- a/opm/porsol/blackoil/fluid/MiscibilityLiveOil.hpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityLiveOil.hpp
@@ -37,6 +37,8 @@
 
 #include "MiscibilityProps.hpp"
 
+#include <opm/parser/eclipse/Utility/PvtoTable.hpp>
+
 namespace Opm
 {
     class MiscibilityLiveOil : public MiscibilityProps
@@ -44,7 +46,8 @@ namespace Opm
     public:
 	typedef std::vector<std::vector<std::vector<double> > > table_t;
 
-	MiscibilityLiveOil(const table_t& pvto);
+    MiscibilityLiveOil(const table_t& pvto);
+	MiscibilityLiveOil(const PvtoTable& pvtoTable);
 	virtual ~MiscibilityLiveOil();
 
         virtual double getViscosity(int region, double press, const surfvol_t& surfvol) const;

--- a/opm/porsol/blackoil/fluid/MiscibilityWater.hpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityWater.hpp
@@ -36,6 +36,8 @@
 
 #include "MiscibilityProps.hpp"
 #include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/parser/eclipse/Utility/PvtwTable.hpp>
+#include <opm/parser/eclipse/Utility/PvcdoTable.hpp>
 
 // Forward declaration.
 class PVTW;
@@ -47,12 +49,12 @@ namespace Opm
     public:
         typedef std::vector<std::vector<double> > table_t;
 
-	MiscibilityWater(const table_t& pvtw)
+        MiscibilityWater(const table_t& pvtw)
         {
-	    const int region_number = 0;
-	    if (pvtw.size() != 1) {
-		OPM_THROW(std::runtime_error, "More than one PVD-region");
-	    }
+            const int region_number = 0;
+            if (pvtw.size() != 1) {
+                OPM_THROW(std::runtime_error, "More than one PVD-region");
+            }
             ref_press_ = pvtw[region_number][0];
             ref_B_     = pvtw[region_number][1];
             comp_      = pvtw[region_number][2];
@@ -62,7 +64,30 @@ namespace Opm
             }
         }
 
-	MiscibilityWater(double visc)
+        MiscibilityWater(const PvtwTable& pvtw)
+        {
+            ref_press_ = pvtw.getPressureColumn()[0];
+            ref_B_     = pvtw.getFormationFactorColumn()[0];
+            comp_      = pvtw.getCompressibilityColumn()[0];
+            viscosity_ = pvtw.getViscosityColumn()[0];
+            if (pvtw.getViscosibilityColumn()[0] != 0.0) {
+                OPM_THROW(std::runtime_error, "MiscibilityWater does not support 'viscosibility'.");
+            }
+        }
+
+        // WTF?? we initialize a class for water from a table for oil.
+        MiscibilityWater(const PvcdoTable& pvcdo)
+        {
+            ref_press_ = pvcdo.getPressureColumn()[0];
+            ref_B_     = pvcdo.getFormationFactorColumn()[0];
+            comp_      = pvcdo.getCompressibilityColumn()[0];
+            viscosity_ = pvcdo.getViscosityColumn()[0];
+            if (pvcdo.getViscosibilityColumn()[0] != 0.0) {
+                OPM_THROW(std::runtime_error, "MiscibilityWater does not support 'viscosibility'.");
+            }
+        }
+
+        MiscibilityWater(double visc)
             : ref_press_(0.0),
               ref_B_(1.0),
               comp_(0.0),

--- a/opm/porsol/common/ReservoirPropertyCommon.hpp
+++ b/opm/porsol/common/ReservoirPropertyCommon.hpp
@@ -40,6 +40,8 @@
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
 #include <opm/porsol/common/Matrix.hpp>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
 namespace Opm
 {
 
@@ -72,16 +74,35 @@ namespace Opm
 
         /// @brief Initialize from a grdecl file.
         /// @param parser the parser holding the grdecl data.
-	/// @param global_cell the mapping from cell indices to the logical
-	///                    cartesian indices of the grdecl file.
- 	/// @param perm_threshold lower threshold for permeability.
- 	/// @param rock_list_filename if non-null, the referred string gives
+        /// @param global_cell the mapping from cell indices to the logical
+        ///                    cartesian indices of the grdecl file.
+        /// @param perm_threshold lower threshold for permeability.
+        /// @param rock_list_filename if non-null, the referred string gives
         ///                           the filename for the rock list.
         /// @param use_jfunction_scaling if true, use j-function scaling of capillary
         ///                              pressure, if applicable.
         /// @param sigma interface tension for j-scaling, if applicable.
         /// @param theta angle for j-scaling, if applicable.
         void init(const Opm::EclipseGridParser& parser,
+                  const std::vector<int>& global_cell,
+                  const double perm_threshold = 0.0,
+                  const std::string* rock_list_filename = 0,
+                  const bool use_jfunction_scaling = true,
+                  const double sigma = 1.0,
+                  const double theta = 0.0);
+
+        /// @brief Initialize from a grdecl file.
+        /// @param deck the deck holding the grdecl data.
+        /// @param global_cell the mapping from cell indices to the logical
+        ///                    cartesian indices of the grdecl file.
+        /// @param perm_threshold lower threshold for permeability.
+        /// @param rock_list_filename if non-null, the referred string gives
+        ///                           the filename for the rock list.
+        /// @param use_jfunction_scaling if true, use j-function scaling of capillary
+        ///                              pressure, if applicable.
+        /// @param sigma interface tension for j-scaling, if applicable.
+        /// @param theta angle for j-scaling, if applicable.
+        void init(Opm::DeckConstPtr deck,
                   const std::vector<int>& global_cell,
                   const double perm_threshold = 0.0,
                   const std::string* rock_list_filename = 0,
@@ -209,7 +230,7 @@ namespace Opm
         void writeSintefLegacyFormat(const std::string& grid_prefix) const;
 
     protected:
-	// Methods
+        // Methods
         void assignPorosity(const Opm::EclipseGridParser& parser,
                             const std::vector<int>& global_cell);
         void assignNTG(const Opm::EclipseGridParser& parser,
@@ -222,6 +243,19 @@ namespace Opm
                                 const std::vector<int>& global_cell,
                                 const double perm_threshold);
         void assignRockTable(const Opm::EclipseGridParser& parser,
+                             const std::vector<int>& global_cell);
+        void assignPorosity(Opm::DeckConstPtr deck,
+                            const std::vector<int>& global_cell);
+        void assignNTG(Opm::DeckConstPtr deck,
+                       const std::vector<int>& global_cell);
+        void assignSWCR(Opm::DeckConstPtr deck,
+                        const std::vector<int>& global_cell);
+        void assignSOWCR(Opm::DeckConstPtr deck,
+                         const std::vector<int>& global_cell);
+        void assignPermeability(Opm::DeckConstPtr deck,
+                                const std::vector<int>& global_cell,
+                                const double perm_threshold);
+        void assignRockTable(Opm::DeckConstPtr deck,
                              const std::vector<int>& global_cell);
         void readRocks(const std::string& rock_list_file);
 

--- a/opm/porsol/common/ReservoirPropertyCommon_impl.hpp
+++ b/opm/porsol/common/ReservoirPropertyCommon_impl.hpp
@@ -36,10 +36,11 @@
 #ifndef OPENRS_RESERVOIRPROPERTYCOMMON_IMPL_HEADER
 #define OPENRS_RESERVOIRPROPERTYCOMMON_IMPL_HEADER
 
+#include <opm/core/io/eclipse/EclipseGridInspector.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 
 #include <fstream>
 #include <array>
-#include <opm/core/io/eclipse/EclipseGridInspector.hpp>
 
 namespace Opm
 {
@@ -112,6 +113,72 @@ namespace Opm
             return retval;
         }
 
+        /// @brief
+        ///    Classify and verify a given permeability specification
+        ///    from a structural point of view.  In particular, we
+        ///    verify that there are no off-diagonal permeability
+        ///    components such as @f$k_{xy}@f$ unless the
+        ///    corresponding diagonal components are known as well.
+        ///
+        /// @param deck [in]
+        ///    An Eclipse deck capable of answering which
+        ///    permeability components are present in a given input
+        ///    deck.
+        ///
+        /// @return
+        ///    An enum value with the following possible values:
+        ///        ScalarPerm     only one component was given.
+        ///        DiagonalPerm   more than one component given.
+        ///        TensorPerm     at least one cross-component given.
+        ///        None           no components given.
+        ///        Invalid        invalid set of components given.
+        PermeabilityKind classifyPermeability(Opm::DeckConstPtr deck)
+        {
+            const bool xx = deck->hasKeyword("PERMX" );
+            const bool xy = deck->hasKeyword("PERMXY");
+            const bool xz = deck->hasKeyword("PERMXZ");
+
+            const bool yx = deck->hasKeyword("PERMYX");
+            const bool yy = deck->hasKeyword("PERMY" );
+            const bool yz = deck->hasKeyword("PERMYZ");
+
+            const bool zx = deck->hasKeyword("PERMZX");
+            const bool zy = deck->hasKeyword("PERMZY");
+            const bool zz = deck->hasKeyword("PERMZ" );
+
+            int num_cross_comp = xy + xz + yx + yz + zx + zy;
+            int num_comp       = xx + yy + zz + num_cross_comp;
+            PermeabilityKind retval = None;
+            if (num_cross_comp > 0) {
+                retval = TensorPerm;
+            } else {
+                if (num_comp == 1) {
+                    retval = ScalarPerm;
+                } else if (num_comp >= 2) {
+                    retval = DiagonalPerm;
+                }
+            }
+
+            bool ok = true;
+            if (num_comp > 0) {
+                // At least one tensor component specified on input.
+                // Verify that any remaining components are OK from a
+                // structural point of view.  In particular, there
+                // must not be any cross-components (e.g., k_{xy})
+                // unless the corresponding diagonal component (e.g.,
+                // k_{xx}) is present as well...
+                //
+                ok =        xx || !(xy || xz || yx || zx) ;
+                ok = ok && (yy || !(yx || yz || xy || zy));
+                ok = ok && (zz || !(zx || zy || xz || yz));
+            }
+            if (!ok) {
+                retval = Invalid;
+            }
+
+            return retval;
+        }
+
 
         /// @brief
         ///    Copy isotropic (scalar) permeability to other diagonal
@@ -139,7 +206,6 @@ namespace Opm
             if (kmap[j] == 0) { kmap[j] = kmap[i]; }
             if (kmap[k] == 0) { kmap[k] = kmap[i]; }
         }
-
 
         /// @brief
         ///   Extract pointers to appropriate tensor components from
@@ -241,6 +307,107 @@ namespace Opm
             return kind;
         }
 
+
+        /// @brief
+        ///   Extract pointers to appropriate tensor components from
+        ///   input deck.  The permeability tensor is, generally,
+        ///   @code
+        ///        [ kxx  kxy  kxz ]
+        ///    K = [ kyx  kyy  kyz ]
+        ///        [ kzx  kzy  kzz ]
+        ///   @endcode
+        ///   We store these values in a linear std::array using natural
+        ///   ordering with the column index cycling the most rapidly.
+        ///   In particular we use the representation
+        ///   @code
+        ///        [  0    1    2    3    4    5    6    7    8  ]
+        ///    K = [ kxx, kxy, kxz, kyx, kyy, kyz, kzx, kzy, kzz ]
+        ///   @endcode
+        ///   Moreover, we explicitly enforce symmetric tensors by
+        ///   assigning
+        ///   @code
+        ///     3     1       6     2       7     5
+        ///    kyx = kxy,    kzx = kxz,    kzy = kyz
+        ///   @endcode
+        ///   However, we make no attempt at enforcing positive
+        ///   definite tensors.
+        ///
+        /// @param [in]  deck
+        ///    An Eclipse deck capable of answering which
+        ///    permeability components are present in a given input
+        ///    deck as well as retrieving the numerical value of each
+        ///    permeability component in each grid cell.
+        ///
+        /// @param [out] tensor
+        /// @param [out] kmap
+        PermeabilityKind fillTensor(Opm::DeckConstPtr deck,
+                                    std::vector<const std::vector<double>*>& tensor,
+                                    std::array<int,9>&                     kmap)
+        {
+            PermeabilityKind kind = classifyPermeability(deck);
+            if (kind == Invalid) {
+                OPM_THROW(std::runtime_error, "Invalid set of permeability fields given.");
+            }
+            assert (tensor.size() == 1);
+            for (int i = 0; i < 9; ++i) { kmap[i] = 0; }
+
+            enum { xx, xy, xz,    // 0, 1, 2
+                   yx, yy, yz,    // 3, 4, 5
+                   zx, zy, zz };  // 6, 7, 8
+
+            // -----------------------------------------------------------
+            // 1st row: [kxx, kxy, kxz]
+            if (deck->hasKeyword("PERMX" )) {
+                kmap[xx] = tensor.size();
+                tensor.push_back(&deck->getKeyword("PERMX")->getSIDoubleData());
+
+                setScalarPermIfNeeded(kmap, xx, yy, zz);
+            }
+            if (deck->hasKeyword("PERMXY")) {
+                kmap[xy] = kmap[yx] = tensor.size();  // Enforce symmetry.
+                tensor.push_back(&deck->getKeyword("PERMXY")->getSIDoubleData());
+            }
+            if (deck->hasKeyword("PERMXZ")) {
+                kmap[xz] = kmap[zx] = tensor.size();  // Enforce symmetry.
+                tensor.push_back(&deck->getKeyword("PERMXZ")->getSIDoubleData());
+            }
+
+            // -----------------------------------------------------------
+            // 2nd row: [kyx, kyy, kyz]
+            if (deck->hasKeyword("PERMYX")) {
+                kmap[yx] = kmap[xy] = tensor.size();  // Enforce symmetry.
+                tensor.push_back(&deck->getKeyword("PERMYX")->getSIDoubleData());
+            }
+            if (deck->hasKeyword("PERMY" )) {
+                kmap[yy] = tensor.size();
+                tensor.push_back(&deck->getKeyword("PERMY")->getSIDoubleData());
+
+                setScalarPermIfNeeded(kmap, yy, zz, xx);
+            }
+            if (deck->hasKeyword("PERMYZ")) {
+                kmap[yz] = kmap[zy] = tensor.size();  // Enforce symmetry.
+                tensor.push_back(&deck->getKeyword("PERMYZ")->getSIDoubleData());
+            }
+
+            // -----------------------------------------------------------
+            // 3rd row: [kzx, kzy, kzz]
+            if (deck->hasKeyword("PERMZX")) {
+                kmap[zx] = kmap[xz] = tensor.size();  // Enforce symmetry.
+                tensor.push_back(&deck->getKeyword("PERMZX")->getSIDoubleData());
+            }
+            if (deck->hasKeyword("PERMZY")) {
+                kmap[zy] = kmap[yz] = tensor.size();  // Enforce symmetry.
+                tensor.push_back(&deck->getKeyword("PERMZY")->getSIDoubleData());
+            }
+            if (deck->hasKeyword("PERMZ" )) {
+                kmap[zz] = tensor.size();
+                tensor.push_back(&deck->getKeyword("PERMZ")->getSIDoubleData());
+
+                setScalarPermIfNeeded(kmap, zz, xx, yy);
+            }
+            return kind;
+        }
+
     } // anonymous namespace
 
 
@@ -268,7 +435,6 @@ namespace Opm
     {
     }
 
-
     template <int dim, class RPImpl, class RockType>
     void ReservoirPropertyCommon<dim, RPImpl, RockType>::init(const Opm::EclipseGridParser& parser,
                                                               const std::vector<int>& global_cell,
@@ -290,6 +456,48 @@ namespace Opm
         assignSOWCR       (parser, global_cell);
         assignPermeability(parser, global_cell, perm_threshold);
         assignRockTable   (parser, global_cell);
+
+        if (rock_list_filename) {
+            readRocks(*rock_list_filename);
+        }
+
+        // Added section. This is a hack, because not all rock classes
+        // may care about J-scaling. They still have to implement
+        // setUseJfunctionScaling() and setSigmaAndTheta(), though the
+        // latter may throw if called for a rock where it does not make sense.
+        int num_rocks = rock_.size();
+        for (int i = 0; i < num_rocks; ++i) {
+            rock_[i].setUseJfunctionScaling(use_jfunction_scaling);
+            if (use_jfunction_scaling) {
+                rock_[i].setSigmaAndTheta(sigma, theta);
+            }
+        }
+        // End of added section.
+
+        asImpl().computeCflFactors();
+    }
+
+    template <int dim, class RPImpl, class RockType>
+    void ReservoirPropertyCommon<dim, RPImpl, RockType>::init(Opm::DeckConstPtr deck,
+                                                              const std::vector<int>& global_cell,
+                                                              const double perm_threshold,
+                                                              const std::string* rock_list_filename,
+                                                              const bool use_jfunction_scaling,
+                                                              const double sigma,
+                                                              const double theta)
+    {
+        // This code is mostly copied from ReservoirPropertyCommon::init(...).
+        static_assert(dim == 3, "");
+
+        permfield_valid_.assign(global_cell.size(),
+                                std::vector<unsigned char>::value_type(0));
+
+        assignPorosity    (deck, global_cell);
+        assignNTG         (deck, global_cell);
+        assignSWCR        (deck, global_cell);
+        assignSOWCR       (deck, global_cell);
+        assignPermeability(deck, global_cell, perm_threshold);
+        assignRockTable   (deck, global_cell);
 
         if (rock_list_filename) {
             readRocks(*rock_list_filename);
@@ -583,9 +791,6 @@ namespace Opm
         return static_cast<RPImpl&>(*this);
     }
 
-
-
-
     template <int dim, class RPImpl, class RockType>
     void ReservoirPropertyCommon<dim, RPImpl, RockType>::assignPorosity(const Opm::EclipseGridParser& parser,
                                                          const std::vector<int>& global_cell)
@@ -651,6 +856,7 @@ namespace Opm
             }
         }
     }
+
 
     template <int dim, class RPImpl, class RockType>
     void ReservoirPropertyCommon<dim, RPImpl, RockType>::assignSOWCR(const Opm::EclipseGridParser& parser,
@@ -719,6 +925,7 @@ namespace Opm
                 int       kix  = 0;
                 const int glob = global_cell[c];
 
+
                 for (int i = 0; i < dim; ++i) {
                     for (int j = 0; j < dim; ++j, ++kix) {
                         K(i,j) = (*tensor[kmap[kix]])[glob];
@@ -755,13 +962,203 @@ namespace Opm
             for (int c = 0; c < nc; ++c) {
                 // Note: SATNUM is FORTRANish, ranging from 1 to n, therefore we subtract one.
                 cell_to_rock_[c] = satnum[global_cell[c]] - 1;
-            }
+             }
         }
         else if (parser.hasField("ROCKTYPE")) {
             Opm::EclipseGridInspector insp(parser);
             std::array<int, 3> dims = insp.gridSize();
             int num_global_cells = dims[0]*dims[1]*dims[2];
             const std::vector<int>& satnum = parser.getIntegerValue("ROCKTYPE");
+            if (int(satnum.size()) != num_global_cells) {
+                OPM_THROW(std::runtime_error, "ROCKTYPE field must have the same size as the "
+                      "logical cartesian size of the grid: "
+                      << satnum.size() << " != " << num_global_cells);
+            }
+            for (int c = 0; c < nc; ++c) {
+                // Note: ROCKTYPE is FORTRANish, ranging from 1 to n, therefore we subtract one.
+                cell_to_rock_[c] = satnum[global_cell[c]] - 1;
+            }
+        }
+    }
+
+    template <int dim, class RPImpl, class RockType>
+    void ReservoirPropertyCommon<dim, RPImpl, RockType>::assignPorosity(Opm::DeckConstPtr deck,
+                                                                        const std::vector<int>& global_cell)
+    {
+        porosity_.assign(global_cell.size(), 1.0);
+
+        if (deck->hasKeyword("PORO")) {
+            Opm::EclipseGridInspector insp(deck);
+            std::array<int, 3> dims = insp.gridSize();
+            int num_global_cells = dims[0]*dims[1]*dims[2];
+            const std::vector<double>& poro = deck->getKeyword("PORO")->getSIDoubleData();
+            if (int(poro.size()) != num_global_cells) {
+                OPM_THROW(std::runtime_error, "PORO field must have the same size as the "
+                      "logical cartesian size of the grid: "
+                      << poro.size() << " != " << num_global_cells);
+            }
+            for (int c = 0; c < int(porosity_.size()); ++c) {
+                porosity_[c] = poro[global_cell[c]];
+            }
+        }
+    }
+
+    template <int dim, class RPImpl, class RockType>
+    void ReservoirPropertyCommon<dim, RPImpl, RockType>::assignNTG(Opm::DeckConstPtr deck,
+                                                                   const std::vector<int>& global_cell)
+    {
+        ntg_.assign(global_cell.size(), 1.0);
+
+        if (deck->hasKeyword("NTG")) {
+            Opm::EclipseGridInspector insp(deck);
+            std::array<int, 3> dims = insp.gridSize();
+            int num_global_cells = dims[0]*dims[1]*dims[2];
+            const std::vector<double>& ntg = deck->getKeyword("NTG")->getSIDoubleData();
+            if (int(ntg.size()) != num_global_cells) {
+                OPM_THROW(std::runtime_error, "NTG field must have the same size as the "
+                      "logical cartesian size of the grid: "
+                      << ntg.size() << " != " << num_global_cells);
+            }
+            for (int c = 0; c < int(ntg_.size()); ++c) {
+                ntg_[c] = ntg[global_cell[c]];
+            }
+        }
+    }
+
+    template <int dim, class RPImpl, class RockType>
+    void ReservoirPropertyCommon<dim, RPImpl, RockType>::assignSWCR(Opm::DeckConstPtr deck,
+                                                                    const std::vector<int>& global_cell)
+    {
+        swcr_.assign(global_cell.size(), 0.0);
+
+        if (deck->hasKeyword("SWCR")) {
+            Opm::EclipseGridInspector insp(deck);
+            std::array<int, 3> dims = insp.gridSize();
+            int num_global_cells = dims[0]*dims[1]*dims[2];
+            const std::vector<double>& swcr =
+                deck->getKeyword("SWCR")->getSIDoubleData();
+            if (int(swcr.size()) != num_global_cells) {
+                OPM_THROW(std::runtime_error, "SWCR field must have the same size as the "
+                      "logical cartesian size of the grid: "
+                      << swcr.size() << " != " << num_global_cells);
+            }
+            for (int c = 0; c < int(swcr_.size()); ++c) {
+                swcr_[c] = swcr[global_cell[c]];
+            }
+        }
+    }
+
+    template <int dim, class RPImpl, class RockType>
+    void ReservoirPropertyCommon<dim, RPImpl, RockType>::assignSOWCR(Opm::DeckConstPtr deck,
+                                                                     const std::vector<int>& global_cell)
+    {
+        sowcr_.assign(global_cell.size(), 0.0);
+
+        if (deck->hasKeyword("SOWCR")) {
+            Opm::EclipseGridInspector insp(deck);
+            std::array<int, 3> dims = insp.gridSize();
+            int num_global_cells = dims[0]*dims[1]*dims[2];
+            const std::vector<double>& sowcr =
+                deck->getKeyword("SOWCR")->getSIDoubleData();
+            if (int(sowcr.size()) != num_global_cells) {
+                OPM_THROW(std::runtime_error, "SOWCR field must have the same size as the "
+                      "logical cartesian size of the grid: "
+                      << sowcr.size() << " != " << num_global_cells);
+            }
+            for (int c = 0; c < int(sowcr_.size()); ++c) {
+                sowcr_[c] = sowcr[global_cell[c]];
+            }
+        }
+    }
+
+    template <int dim, class RPImpl, class RockType>
+    void ReservoirPropertyCommon<dim, RPImpl, RockType>::assignPermeability(Opm::DeckConstPtr deck,
+                                                                            const std::vector<int>& global_cell,
+                                                                            double perm_threshold)
+    {
+        Opm::EclipseGridInspector insp(deck);
+        std::array<int, 3> dims = insp.gridSize();
+        int num_global_cells = dims[0]*dims[1]*dims[2];
+        assert (num_global_cells > 0);
+
+        permeability_.assign(dim * dim * global_cell.size(), 0.0);
+
+        std::vector<const std::vector<double>*> tensor;
+        tensor.reserve(10);
+
+        const std::vector<double> zero(num_global_cells, 0.0);
+        tensor.push_back(&zero);
+
+        static_assert(dim == 3, "");
+        std::array<int,9> kmap;
+        permeability_kind_ = fillTensor(deck, tensor, kmap);
+        for (int i = 1; i < int(tensor.size()); ++i) {
+            if (int(tensor[i]->size()) != num_global_cells) {
+                OPM_THROW(std::runtime_error, "All permeability fields must have the same size as the "
+                      "logical cartesian size of the grid: "
+                      << (tensor[i]->size()) << " != " << num_global_cells);
+            }
+        }
+
+        // Assign permeability values only if such values are
+        // given in the input deck represented by 'deck'.  In
+        // other words: Don't set any (arbitrary) default values.
+        // It is infinitely better to experience a reproducible
+        // crash than subtle errors resulting from a (poorly
+        // chosen) default value...
+        //
+        if (tensor.size() > 1) {
+            const int nc  = global_cell.size();
+            int       off = 0;
+
+            for (int c = 0; c < nc; ++c, off += dim*dim) {
+                SharedPermTensor K(dim, dim, &permeability_[off]);
+                int       kix  = 0;
+                const int glob = global_cell[c];
+
+                for (int i = 0; i < dim; ++i) {
+                    for (int j = 0; j < dim; ++j, ++kix) {
+                        K(i,j) = (*tensor[kmap[kix]])[glob];
+                    }
+                    K(i,i) = std::max(K(i,i), perm_threshold);
+                }
+
+                permfield_valid_[c] = std::vector<unsigned char>::value_type(1);
+            }
+        }
+    }
+
+
+
+
+    template <int dim, class RPImpl, class RockType>
+    void ReservoirPropertyCommon<dim, RPImpl, RockType>::assignRockTable(Opm::DeckConstPtr deck,
+                                                          const std::vector<int>& global_cell)
+    {
+        const int nc = global_cell.size();
+
+        cell_to_rock_.assign(nc, 0);
+
+        if (deck->hasKeyword("SATNUM")) {
+            Opm::EclipseGridInspector insp(deck);
+            std::array<int, 3> dims = insp.gridSize();
+            int num_global_cells = dims[0]*dims[1]*dims[2];
+            const std::vector<int>& satnum = deck->getKeyword("SATNUM")->getIntData();
+            if (int(satnum.size()) != num_global_cells) {
+                OPM_THROW(std::runtime_error, "SATNUM field must have the same size as the "
+                      "logical cartesian size of the grid: "
+                      << satnum.size() << " != " << num_global_cells);
+            }
+            for (int c = 0; c < nc; ++c) {
+                // Note: SATNUM is FORTRANish, ranging from 1 to n, therefore we subtract one.
+                cell_to_rock_[c] = satnum[global_cell[c]] - 1;
+            }
+        }
+        else if (deck->hasKeyword("ROCKTYPE")) {
+            Opm::EclipseGridInspector insp(deck);
+            std::array<int, 3> dims = insp.gridSize();
+            int num_global_cells = dims[0]*dims[1]*dims[2];
+            const std::vector<int>& satnum = deck->getKeyword("ROCKTYPE")->getIntData();
             if (int(satnum.size()) != num_global_cells) {
                 OPM_THROW(std::runtime_error, "ROCKTYPE field must have the same size as the "
                       "logical cartesian size of the grid: "

--- a/opm/porsol/common/Rock.hpp
+++ b/opm/porsol/common/Rock.hpp
@@ -23,8 +23,9 @@
 
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
 #include <opm/porsol/common/Matrix.hpp>
-
 #include <opm/porsol/common/ReservoirPropertyCommon.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 
 namespace Opm
 {
@@ -48,16 +49,32 @@ namespace Opm
 
         /// @brief Initialize from a grdecl file.
         /// @param parser the parser holding the grdecl data.
-	/// @param global_cell the mapping from cell indices to the logical
-	///                    cartesian indices of the grdecl file.
- 	/// @param perm_threshold lower threshold for permeability.
- 	/// @param rock_list_filename if non-null, the referred string gives
+        /// @param global_cell the mapping from cell indices to the logical
+        ///                    cartesian indices of the grdecl file.
+        /// @param perm_threshold lower threshold for permeability.
+        /// @param rock_list_filename if non-null, the referred string gives
         ///                           the filename for the rock list.
         /// @param use_jfunction_scaling if true, use j-function scaling of capillary
         ///                              pressure, if applicable.
         /// @param sigma interface tension for j-scaling, if applicable.
         /// @param theta angle for j-scaling, if applicable.
         void init(const Opm::EclipseGridParser& parser,
+                  const std::vector<int>& global_cell,
+                  const double perm_threshold = 0.0);
+
+
+        /// @brief Initialize from a grdecl file.
+        /// @param parser the parser holding the grdecl data.
+        /// @param global_cell the mapping from cell indices to the logical
+        ///                    cartesian indices of the grdecl file.
+        /// @param perm_threshold lower threshold for permeability.
+        /// @param rock_list_filename if non-null, the referred string gives
+        ///                           the filename for the rock list.
+        /// @param use_jfunction_scaling if true, use j-function scaling of capillary
+        ///                              pressure, if applicable.
+        /// @param sigma interface tension for j-scaling, if applicable.
+        /// @param theta angle for j-scaling, if applicable.
+        void init(Opm::DeckConstPtr deck,
                   const std::vector<int>& global_cell,
                   const double perm_threshold = 0.0);
 
@@ -86,14 +103,20 @@ namespace Opm
 	SharedPermTensor permeabilityModifiable(int cell_index);
 
     protected:
-	// Methods
+        // Methods
         void assignPorosity(const Opm::EclipseGridParser& parser,
                             const std::vector<int>& global_cell);
         void assignPermeability(const Opm::EclipseGridParser& parser,
                                 const std::vector<int>& global_cell,
                                 const double perm_threshold);
 
-	// Data members.
+        void assignPorosity(Opm::DeckConstPtr deck,
+                            const std::vector<int>& global_cell);
+        void assignPermeability(Opm::DeckConstPtr deck,
+                                const std::vector<int>& global_cell,
+                                const double perm_threshold);
+
+        // Data members.
         std::vector<double>        porosity_;
         std::vector<double>        permeability_;
         std::vector<unsigned char> permfield_valid_;

--- a/opm/porsol/common/Rock_impl.hpp
+++ b/opm/porsol/common/Rock_impl.hpp
@@ -39,7 +39,6 @@ namespace Opm
     {
     }
 
-
     template <int dim>
     void Rock<dim>::init(const Opm::EclipseGridParser& parser,
                          const std::vector<int>& global_cell,
@@ -52,6 +51,20 @@ namespace Opm
 
         assignPorosity    (parser, global_cell);
         assignPermeability(parser, global_cell, perm_threshold);
+    }
+
+    template <int dim>
+    void Rock<dim>::init(Opm::DeckConstPtr deck,
+                         const std::vector<int>& global_cell,
+                         const double perm_threshold)
+    {
+        // This code is mostly copied from ReservoirPropertyCommon::init(...).
+        static_assert(dim == 3, "");
+
+        permfield_valid_.assign(global_cell.size(), false);
+
+        assignPorosity    (deck, global_cell);
+        assignPermeability(deck, global_cell, perm_threshold);
     }
 
 
@@ -109,8 +122,6 @@ namespace Opm
     // ------ Private methods ------
 
 
-
-
     template <int dim>
     void Rock<dim>::assignPorosity(const Opm::EclipseGridParser& parser,
                                    const std::vector<int>& global_cell)
@@ -127,13 +138,12 @@ namespace Opm
     }
 
 
-
     template <int dim>
     void Rock<dim>::assignPermeability(const Opm::EclipseGridParser& parser,
                                        const std::vector<int>& global_cell,
                                        double perm_threshold)
     {
-	Opm::EclipseGridInspector insp(parser);
+        Opm::EclipseGridInspector insp(parser);
         std::array<int, 3> dims = insp.gridSize();
         int num_global_cells = dims[0]*dims[1]*dims[2];
         assert (num_global_cells > 0);
@@ -152,6 +162,73 @@ namespace Opm
 
         // Assign permeability values only if such values are
         // given in the input deck represented by 'parser'.  In
+        // other words: Don't set any (arbitrary) default values.
+        // It is infinitely better to experience a reproducible
+        // crash than subtle errors resulting from a (poorly
+        // chosen) default value...
+        //
+        if (tensor.size() > 1) {
+            const int nc  = global_cell.size();
+            int       off = 0;
+
+            for (int c = 0; c < nc; ++c, off += dim*dim) {
+                SharedPermTensor K(dim, dim, &permeability_[off]);
+                int       kix  = 0;
+                const int glob = global_cell[c];
+
+                for (int i = 0; i < dim; ++i) {
+                    for (int j = 0; j < dim; ++j, ++kix) {
+                        K(i,j) = (*tensor[kmap[kix]])[glob];
+                    }
+                    K(i,i) = std::max(K(i,i), perm_threshold);
+                }
+
+                permfield_valid_[c] = std::vector<unsigned char>::value_type(1);
+            }
+        }
+    }
+
+    template <int dim>
+    void Rock<dim>::assignPorosity(Opm::DeckConstPtr deck,
+                                   const std::vector<int>& global_cell)
+    {
+        porosity_.assign(global_cell.size(), 1.0);
+
+        if (deck->hasKeyword("PORO")) {
+            const std::vector<double>& poro = deck->getKeyword("PORO")->getSIDoubleData();
+
+            for (int c = 0; c < int(porosity_.size()); ++c) {
+                porosity_[c] = poro[global_cell[c]];
+            }
+        }
+    }
+
+
+
+    template <int dim>
+    void Rock<dim>::assignPermeability(Opm::DeckConstPtr deck,
+                                       const std::vector<int>& global_cell,
+                                       double perm_threshold)
+    {
+        Opm::EclipseGridInspector insp(deck);
+        std::array<int, 3> dims = insp.gridSize();
+        int num_global_cells = dims[0]*dims[1]*dims[2];
+        assert (num_global_cells > 0);
+
+        permeability_.assign(dim * dim * global_cell.size(), 0.0);
+
+        std::vector<const std::vector<double>*> tensor;
+        tensor.reserve(10);
+
+        const std::vector<double> zero(num_global_cells, 0.0);
+        tensor.push_back(&zero);
+
+        static_assert(dim == 3, "");
+        std::array<int,9> kmap;
+        permeability_kind_ = fillTensor(deck, tensor, kmap);
+
+        // Assign permeability values only if such values are
+        // given in the input deck represented by 'deck'.  In
         // other words: Don't set any (arbitrary) default values.
         // It is infinitely better to experience a reproducible
         // crash than subtle errors resulting from a (poorly


### PR DESCRIPTION
this PR adds the opm-parser support code which is required to convert the remaining modules. after this, the whole thing will become a downhill struggle as the old parser doesn't have to be supported by the "leaf" modules and can thus be removed directly.

All ctests for opm-porsol and opm-upscaling still pass, opm-polymer does not build on my machine because of OPM/opm-polymer#57 being not yet merged...
