### PR TITLE
fix the build on Dune 2.4

### DIFF
--- a/examples/sim_co2_impes.cpp
+++ b/examples/sim_co2_impes.cpp
@@ -26,6 +26,7 @@
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
+#include <dune/common/mpihelper.hh>
 #endif
 
 #include <opm/porsol/common/SimulatorUtilities.hpp>
@@ -41,7 +42,6 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
 #include <dune/grid/CpGrid.hpp>
-#include <dune/common/mpihelper.hh>
 
 #include <iostream>
 


### PR DESCRIPTION
for some reason, the MPIHelper was included using its 2.3 location,
but the old `#include` statement for the old header was not moved to the
`#else` branch of the `DUNE_VERSION_NEWER`. This broke the build on
dune 2.4 where the deprecated location of the file is no longer
available.