### PR TITLE
adapt the location of opm-material's UniformTabulated2DFunction.hpp

### DIFF
--- a/opm/porsol/blackoil/co2fluid/benchmark3co2tables.hh
+++ b/opm/porsol/blackoil/co2fluid/benchmark3co2tables.hh
@@ -27,7 +27,7 @@
 #ifndef OPM_BENCHMARK3_CO2TABLES_HH
 #define OPM_BENCHMARK3_CO2TABLES_HH
 
-#include <opm/material/UniformTabulated2DFunction.hpp>
+#include <opm/material/common/UniformTabulated2DFunction.hpp>
 
 #include <assert.h>
 


### PR DESCRIPTION
this file has been moved from opm/material/ to opm/material/common.

(sorry that I only submitted the PR now, I did the patch together with the other code-moving changes, but the porsol PR was hit by a bus for some reason...)