### PR TITLE
Downstream linker issues

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -38,6 +38,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/porsol/common/BoundaryPeriodicity.cpp
 	opm/porsol/common/LinearSolverISTL.cpp
 	opm/porsol/common/setupGridAndProps.cpp
+	opm/porsol/euler/ImplicitCapillarity.cpp
 	)
 
 # originally generated with the command:

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -35,6 +35,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/porsol/blackoil/fluid/MiscibilityLiveOil.cpp
 	opm/porsol/blackoil/fluid/MiscibilityProps.cpp
 	opm/porsol/common/blas_lapack.cpp
+	opm/porsol/common/BoundaryPeriodicity.cpp
 	opm/porsol/common/LinearSolverISTL.cpp
 	)
 

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -34,6 +34,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/porsol/blackoil/fluid/MiscibilityLiveGas.cpp
 	opm/porsol/blackoil/fluid/MiscibilityLiveOil.cpp
 	opm/porsol/blackoil/fluid/MiscibilityProps.cpp
+	opm/porsol/common/blas_lapack.cpp
 	opm/porsol/common/LinearSolverISTL.cpp
 	)
 

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -37,6 +37,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/porsol/common/blas_lapack.cpp
 	opm/porsol/common/BoundaryPeriodicity.cpp
 	opm/porsol/common/LinearSolverISTL.cpp
+	opm/porsol/common/setupGridAndProps.cpp
 	)
 
 # originally generated with the command:

--- a/opm/porsol/common/BoundaryPeriodicity.cpp
+++ b/opm/porsol/common/BoundaryPeriodicity.cpp
@@ -1,0 +1,51 @@
+/*
+  Copyright 2011 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <opm/porsol/common/BoundaryPeriodicity.hpp>
+
+namespace Opm {
+
+bool match(std::vector<BoundaryFaceInfo>& bfaces, int face, int lower, int upper)
+{
+    const double area_tol = 1e-6;
+    const double centroid_tol = 1e-6;
+    int cp = bfaces[face].canon_pos;
+    int target_cp = (cp%2 == 0) ? cp + 1 : cp - 1;
+    Dune::FieldVector<double, 3> cent_this = bfaces[face].centroid;
+    for (int j = lower; j < upper; ++j) {
+        if (bfaces[j].canon_pos == target_cp) {
+            if (fabs(bfaces[face].area - bfaces[j].area) <= area_tol) {
+                Dune::FieldVector<double, 3> cent_other = bfaces[j].centroid;
+                cent_other -= cent_this;
+                double dist = cent_other.two_norm();
+                if (dist <= centroid_tol) {
+                    bfaces[face].partner_face_index = bfaces[j].face_index;
+                    bfaces[face].partner_bid = bfaces[j].bid;
+                    bfaces[j].partner_face_index = bfaces[face].face_index;
+                    bfaces[j].partner_bid = bfaces[face].bid;
+                    break;
+                }
+            }
+        }
+    }
+    return (bfaces[face].partner_face_index != -1);
+}
+
+}

--- a/opm/porsol/common/BoundaryPeriodicity.hpp
+++ b/opm/porsol/common/BoundaryPeriodicity.hpp
@@ -79,33 +79,7 @@ namespace Opm
     /// @param[in] lower lower end of search interval [lower, upper)
     /// @param[in] upper upper end of search interval [lower, upper)
     /// @return true if a match was found, otherwise false
-    bool match(std::vector<BoundaryFaceInfo>& bfaces, int face, int lower, int upper)
-    {
-	const double area_tol = 1e-6;
-	const double centroid_tol = 1e-6;
-	int cp = bfaces[face].canon_pos;
-	int target_cp = (cp%2 == 0) ? cp + 1 : cp - 1;
-	Dune::FieldVector<double, 3> cent_this = bfaces[face].centroid;
-	for (int j = lower; j < upper; ++j) {
-	    if (bfaces[j].canon_pos == target_cp) {
-		if (fabs(bfaces[face].area - bfaces[j].area) <= area_tol) {
-		    Dune::FieldVector<double, 3> cent_other = bfaces[j].centroid;
-		    cent_other -= cent_this;
-		    double dist = cent_other.two_norm();
-		    if (dist <= centroid_tol) {
-			bfaces[face].partner_face_index = bfaces[j].face_index;
-			bfaces[face].partner_bid = bfaces[j].bid;
-			bfaces[j].partner_face_index = bfaces[face].face_index;
-			bfaces[j].partner_bid = bfaces[face].bid;
-			break;
-		    }
-		}
-	    }
-	}
-	return (bfaces[face].partner_face_index != -1);
-    }
-
-
+    bool match(std::vector<BoundaryFaceInfo>& bfaces, int face, int lower, int upper);
 
     /// @brief Common implementation for the various createPeriodic functions.
     template <class GridView>

--- a/opm/porsol/common/blas_lapack.cpp
+++ b/opm/porsol/common/blas_lapack.cpp
@@ -1,0 +1,130 @@
+//===========================================================================
+//
+// File: blas_lapack.cpp
+//
+// Created: Sun Jun 21 18:56:51 2009
+//
+// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Atgeirr F Rasmussen <atgeirr@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of The Open Reservoir Simulator Project (OpenRS).
+
+  OpenRS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OpenRS is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OpenRS.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/porsol/common/blas_lapack.hpp>
+
+namespace Opm {
+namespace BLAS_LAPACK {
+
+template<>
+void GEMV<double>(const char*   transA,
+                  const int     m     , const int     n,
+                  const double& a1    , const double* A, const int ldA,
+                                        const double* x, const int incX,
+                  const double& a2    ,       double* y, const int incY)
+{
+    assert((transA[0] == 'N') || (transA[0] == 'T'));
+
+    DGEMV(F77_CHARACTER(transA[0]),
+          &m, &n, &a1, A, &ldA, x, &incX, &a2, y, &incY);
+}
+
+template<>
+void GEMM<double>(const char*   transA, const char*   transB,
+                  const int     m     , const int     n     , const int k  ,
+                  const double& a1    , const double* A     , const int ldA,
+                                        const double* B     , const int ldB,
+                  const double& a2    ,       double* C     , const int ldC)
+{
+    assert((transA[0] == 'N') || (transA[0] == 'T'));
+    assert((transB[0] == 'N') || (transB[0] == 'T'));
+
+    DGEMM(F77_CHARACTER(transA[0]), F77_CHARACTER(transB[0]),
+          &m, &n, &k, &a1, A, &ldA, B, &ldB, &a2, C, &ldC);
+}
+
+template<>
+void SYRK<double>(const char*   uplo, const char*   trans,
+                  const int     n   , const int     k    ,
+                  const double& a1  , const double* A    , const int ldA,
+                  const double& a2  ,       double* C    , const int ldC)
+{
+    assert((uplo[0]  == 'U') || (uplo[0]  == 'L'));
+    assert((trans[0] == 'N') || (trans[0] == 'T'));
+
+    DSYRK(F77_CHARACTER(uplo[0]), F77_CHARACTER(trans[0]),
+          &n, &k, &a1, A, &ldA, &a2, C, &ldC);
+}
+
+template<>
+void TRMM<double>(const char*   side  , const char* uplo,
+                  const char*   transA, const char* diag,
+                  const int     m     , const int   n   , const double& a,
+                  const double* A     , const int   ldA ,
+                        double* B     , const int   ldB)
+{
+    assert((side[0]   == 'L') || (side[0]   == 'R'));
+    assert((uplo[0]   == 'U') || (uplo[0]   == 'L'));
+    assert((transA[0] == 'N') || (transA[0] == 'T'));
+    assert((diag[0]   == 'N') || (diag[0]   == 'U'));
+
+    DTRMM(F77_CHARACTER(side[0])  , F77_CHARACTER(uplo[0]),
+          F77_CHARACTER(transA[0]), F77_CHARACTER(diag[0]),
+          &m, &n, &a, A, &ldA, B, &ldB);
+}
+
+template<>
+void GEQRF<double>(const int     m    , const int     n   ,
+                         double* A    , const int     ld  ,
+                         double* tau  ,       double* work,
+                   const int     lwork,       int&    info)
+{
+    DGEQRF(&m, &n, A, &ld, tau, work, &lwork, &info);
+}
+
+template<>
+void ORGQR<double>(const int     m   , const int n    , const int     k  ,
+                         double* A   , const int ld   , const double* tau,
+                         double* work, const int lwork,       int&    info)
+{
+    DORGQR(&m, &n, &k, A, &ld, tau, work, &lwork, &info);
+}
+
+template<>
+void GETRF<double>(const int m, const int n , double* A,
+                   const int ld, int* ipiv, int& info)
+{
+    DGETRF(&m, &n, A, &ld, ipiv, &info);
+}
+
+template<>
+void GETRI(const int  n   , double* A   , const int ld,
+           const int* ipiv, double* work, int lwork, int& info)
+{
+    DGETRI(&n, A, &ld, ipiv, work, &lwork, &info);
+}
+
+}
+}

--- a/opm/porsol/common/blas_lapack.hpp
+++ b/opm/porsol/common/blas_lapack.hpp
@@ -196,14 +196,7 @@ namespace Opm {
                           const int     m     , const int     n,
                           const double& a1    , const double* A, const int ldA,
                                                 const double* x, const int incX,
-                          const double& a2    ,       double* y, const int incY)
-        {
-            assert((transA[0] == 'N') || (transA[0] == 'T'));
-
-            DGEMV(F77_CHARACTER(transA[0]),
-                  &m, &n, &a1, A, &ldA, x, &incX, &a2, y, &incY);
-        }
-
+                          const double& a2    ,       double* y, const int incY);
 
         //--------------------------------------------------------------------------
         /// @brief GEneral Matrix Matrix product (Level 3 BLAS).
@@ -278,14 +271,7 @@ namespace Opm {
                           const int     m     , const int     n     , const int k  ,
                           const double& a1    , const double* A     , const int ldA,
                                                 const double* B     , const int ldB,
-                          const double& a2    ,       double* C     , const int ldC)
-        {
-            assert((transA[0] == 'N') || (transA[0] == 'T'));
-            assert((transB[0] == 'N') || (transB[0] == 'T'));
-
-            DGEMM(F77_CHARACTER(transA[0]), F77_CHARACTER(transB[0]),
-                  &m, &n, &k, &a1, A, &ldA, B, &ldB, &a2, C, &ldC);
-        }
+                          const double& a2    ,       double* C     , const int ldC);
 
 
         //--------------------------------------------------------------------------
@@ -303,16 +289,7 @@ namespace Opm {
         void SYRK<double>(const char*   uplo, const char*   trans,
                           const int     n   , const int     k    ,
                           const double& a1  , const double* A    , const int ldA,
-                          const double& a2  ,       double* C    , const int ldC)
-        {
-            assert((uplo[0]  == 'U') || (uplo[0]  == 'L'));
-            assert((trans[0] == 'N') || (trans[0] == 'T'));
-
-            DSYRK(F77_CHARACTER(uplo[0]), F77_CHARACTER(trans[0]),
-                  &n, &k, &a1, A, &ldA, &a2, C, &ldC);
-        }
-
-
+                          const double& a2  ,       double* C    , const int ldC);
 
         //--------------------------------------------------------------------------
         /// @brief TRiangular Matrix Matrix product (Level 2 BLAS)
@@ -331,18 +308,7 @@ namespace Opm {
                           const char*   transA, const char* diag,
                           const int     m     , const int   n   , const double& a,
                           const double* A     , const int   ldA ,
-                                double* B     , const int   ldB)
-        {
-            assert((side[0]   == 'L') || (side[0]   == 'R'));
-            assert((uplo[0]   == 'U') || (uplo[0]   == 'L'));
-            assert((transA[0] == 'N') || (transA[0] == 'T'));
-            assert((diag[0]   == 'N') || (diag[0]   == 'U'));
-
-            DTRMM(F77_CHARACTER(side[0])  , F77_CHARACTER(uplo[0]),
-                  F77_CHARACTER(transA[0]), F77_CHARACTER(diag[0]),
-                  &m, &n, &a, A, &ldA, B, &ldB);
-        }
-
+                                double* B     , const int   ldB);
 
         //--------------------------------------------------------------------------
         /// @brief GEneral matrix QR Factorization (LAPACK)
@@ -359,11 +325,7 @@ namespace Opm {
         void GEQRF<double>(const int     m    , const int     n   ,
                                  double* A    , const int     ld  ,
                                  double* tau  ,       double* work,
-                           const int     lwork,       int&    info)
-        {
-            DGEQRF(&m, &n, A, &ld, tau, work, &lwork, &info);
-        }
-
+                           const int     lwork,       int&    info);
 
         //--------------------------------------------------------------------------
         /// @brief ORthogonal matrix Generator from QR factorization (LAPACK).
@@ -380,11 +342,7 @@ namespace Opm {
         template<>
         void ORGQR<double>(const int     m   , const int n    , const int     k  ,
                                  double* A   , const int ld   , const double* tau,
-                                 double* work, const int lwork,       int&    info)
-        {
-            DORGQR(&m, &n, &k, A, &ld, tau, work, &lwork, &info);
-        }
-
+                                 double* work, const int lwork,       int&    info);
 
         //--------------------------------------------------------------------------
         /// @brief GEneral matrix TRiangular Factorization (LAPACK).
@@ -398,12 +356,7 @@ namespace Opm {
         ///    GEneral matrix TRiangular Factorization specialization for double.
         template<>
         void GETRF<double>(const int m, const int n , double* A,
-                           const int ld, int* ipiv, int& info)
-        {
-            DGETRF(&m, &n, A, &ld, ipiv, &info);
-        }
-
-
+                           const int ld, int* ipiv, int& info);
 
         //--------------------------------------------------------------------------
         /// @brief GEneral matrix TRiangular Inversion (LAPACK).
@@ -416,10 +369,7 @@ namespace Opm {
         /// @brief GEneral matrix TRiangular Inversion specialization for double.
         template<>
         void GETRI(const int  n   , double* A   , const int ld,
-                   const int* ipiv, double* work, int lwork, int& info)
-        {
-            DGETRI(&n, A, &ld, ipiv, work, &lwork, &info);
-        }
+                   const int* ipiv, double* work, int lwork, int& info);
     } // namespace BLAS_LAPACK
 } // namespace Opm
 

--- a/opm/porsol/common/setupGridAndProps.cpp
+++ b/opm/porsol/common/setupGridAndProps.cpp
@@ -1,0 +1,47 @@
+//===========================================================================
+//
+// File: setupGridAndProps.cpp
+//
+// Created: Tue Aug 11 14:47:35 2009
+//
+// Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
+//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of The Open Reservoir Simulator Project (OpenRS).
+
+  OpenRS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OpenRS is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OpenRS.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+#include <opm/porsol/common/setupGridAndProps.hpp>
+
+namespace Opm {
+
+template<>
+bool useJ< ReservoirPropertyCapillary<3> >()
+{
+    return true;
+}
+
+}

--- a/opm/porsol/common/setupGridAndProps.hpp
+++ b/opm/porsol/common/setupGridAndProps.hpp
@@ -56,10 +56,7 @@ namespace Opm
     }
 
     template<>
-    bool useJ< ReservoirPropertyCapillary<3> >()
-    {
-        return true;
-    }
+    bool useJ< ReservoirPropertyCapillary<3> >();
 
     /// @brief
     /// @todo Doc me!

--- a/opm/porsol/euler/ImplicitCapillarity.cpp
+++ b/opm/porsol/euler/ImplicitCapillarity.cpp
@@ -1,0 +1,49 @@
+//===========================================================================
+//
+// File: ImplicitCapillarity.cpp
+//
+// Created: Thu May  6 15:36:07 2010
+//
+// Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
+//            Jostein R Natvig    <jostein.r.natvig@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2010 Statoil ASA.
+
+  This file is part of The Open Reservoir Simulator Project (OpenRS).
+
+  OpenRS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OpenRS is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OpenRS.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+#include <opm/porsol/euler/ImplicitCapillarity.hpp>
+#include <algorithm>
+
+namespace Opm {
+namespace ImplicitCapillarityDetails {
+
+void thresholdMobility(double& m, double threshold)
+{
+    m = std::max(m, threshold);
+}
+
+}
+}

--- a/opm/porsol/euler/ImplicitCapillarity_impl.hpp
+++ b/opm/porsol/euler/ImplicitCapillarity_impl.hpp
@@ -119,10 +119,8 @@ namespace Opm
 
 
     namespace ImplicitCapillarityDetails {
-        void thresholdMobility(double& m, double threshold)
-        {
-            m = std::max(m, threshold);
-        }
+        void thresholdMobility(double& m, double threshold);
+
         // The matrix variant expects diagonal mobilities.
         template <class SomeMatrixType>
         void thresholdMobility(SomeMatrixType& m, double threshold)


### PR DESCRIPTION
While trying to refactor some upscaling applications, i ran into lots of linker issues.
The cause is non-template functions in headers (specializations or just bog-standard functions).
Using these headers in sources linked into a library, and then also in an application leads to duplicate symbols.

I'm not sure if these was done like this is for micro-optimizations desires (all of them should be very irrelevant), or if just 'cause it worked and I couldnt be bothered doing it properly'. Hopefully this change is acceptable, if not I cannot (easily) refactor in downstream module(s).