### PR TITLE
Chase parser's refactored table API

### DIFF
--- a/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
+++ b/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
@@ -63,8 +63,9 @@ namespace Opm
         }
 
         // Oil PVT
-        const auto& pvdoTables = eclipseState->getPvdoTables();
-        const auto& pvtoTables = eclipseState->getPvtoTables();
+        const auto& tables     = eclipseState->getTableManager();
+        const auto& pvdoTables = tables->getPvdoTables();
+        const auto& pvtoTables = tables->getPvtoTables();
         if (!pvdoTables.empty()) {
             oil_props_.reset(new MiscibilityDead(pvdoTables[0]));
         } else if (pvtoTables.empty()) {
@@ -78,8 +79,8 @@ namespace Opm
         }
 
 	// Gas PVT
-        const auto& pvdgTables = eclipseState->getPvdgTables();
-        const auto& pvtgTables = eclipseState->getPvtgTables();
+        const auto& pvdgTables = tables->getPvdgTables();
+        const auto& pvtgTables = tables->getPvtgTables();
         if (!pvdgTables.empty()) {
             gas_props_.reset(new MiscibilityDead(pvdgTables[0]));
         } else if (pvtgTables.empty()) {

--- a/opm/porsol/blackoil/fluid/FluidMatrixInteractionBlackoil.hpp
+++ b/opm/porsol/blackoil/fluid/FluidMatrixInteractionBlackoil.hpp
@@ -46,8 +46,9 @@ public:
         ParseMode parseMode;
         EclipseState eclipseState(deck , parseMode);
         // Extract input data.
-        const auto& swofTable = eclipseState.getSwofTables()[0];
-        const auto& sgofTable = eclipseState.getSgofTables()[0];
+        const auto& tables    = eclipseState.getTableManager();
+        const auto& swofTable = tables->getSwofTables()[0];
+        const auto& sgofTable = tables->getSgofTables()[0];
 
         const std::vector<double>& sw = swofTable.getSwColumn();
         const std::vector<double>& krw = swofTable.getKrwColumn();


### PR DESCRIPTION
This commit switches all call sites to using the TableManager API from module opm-parser (PR OPM/opm-parser#570).  Needed to restore build of module opm-porsol (and downstream modules such as opm-upscaling).