### PR TITLE
Bump version and unify format of dune.module.

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -1,12 +1,13 @@
-################################
-# Dune module information file #
-################################
+####################################################################
+# Dune module information file: This file gets parsed by dunecontrol
+# and by the CMake build scripts.
+####################################################################
 
-#Name of the module
 Module: opm-porsol
 Description: DUNE module containing porous media PDE solvers
-Version: 1.0
-Label: 2013.10
+Version: 2016.04-pre
+Label: 2016.04-pre
 Maintainer: atgeirr@sintef.no
-#depending on 
+MaintainerName: Atgeirr F. Rasmussen
+Url: http://opm-project.org
 Depends: dune-common dune-grid dune-istl opm-common opm-core opm-material dune-cornerpoint


### PR DESCRIPTION
After this, all code modules have the same formatting in dune.module, and the correct version name (for the master branch): "2016.04-pre".