### PR TITLE
Fixes includes wrt opm-parser PR-656

### DIFF
--- a/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
+++ b/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
@@ -30,6 +30,9 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Parser/ParseMode.hpp>
 
 using namespace Opm;

--- a/opm/porsol/blackoil/fluid/FluidMatrixInteractionBlackoil.hpp
+++ b/opm/porsol/blackoil/fluid/FluidMatrixInteractionBlackoil.hpp
@@ -25,6 +25,9 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/ParseMode.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include "BlackoilDefs.hpp"
 #include <iostream>
 #include <stdexcept>

--- a/opm/porsol/blackoil/fluid/MiscibilityDead.cpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityDead.cpp
@@ -33,6 +33,8 @@
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/linearInterpolation.hpp>
 #include <opm/core/utility/buildUniformMonotoneTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp>
 #include <boost/lexical_cast.hpp>
 #include <string>
 #include <fstream>

--- a/opm/porsol/blackoil/fluid/MiscibilityDead.hpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityDead.hpp
@@ -41,6 +41,10 @@
 
 namespace Opm
 {
+
+    class PvdoTable;
+    class PvdgTable;
+
     class MiscibilityDead : public MiscibilityProps
     {
     public:

--- a/opm/porsol/blackoil/fluid/MiscibilityLiveGas.cpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityLiveGas.cpp
@@ -33,6 +33,8 @@
 #include "MiscibilityLiveGas.hpp"
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/linearInterpolation.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp>
 
 using namespace std;
 using namespace Opm;

--- a/opm/porsol/blackoil/fluid/MiscibilityLiveGas.hpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityLiveGas.hpp
@@ -40,6 +40,9 @@
 
 namespace Opm
 {
+
+    class PvtgTable;
+
     class MiscibilityLiveGas : public MiscibilityProps
     {
     public:

--- a/opm/porsol/blackoil/fluid/MiscibilityLiveOil.cpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityLiveOil.cpp
@@ -35,6 +35,8 @@
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/linearInterpolation.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp>
 
 using namespace std;
 using namespace Opm;

--- a/opm/porsol/blackoil/fluid/MiscibilityLiveOil.hpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityLiveOil.hpp
@@ -41,6 +41,9 @@
 
 namespace Opm
 {
+
+    class PvtoTable;
+
     class MiscibilityLiveOil : public MiscibilityProps
     {
     public:

--- a/opm/porsol/blackoil/fluid/MiscibilityWater.hpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityWater.hpp
@@ -37,6 +37,9 @@
 #include "MiscibilityProps.hpp"
 #include <opm/common/ErrorMacros.hpp>
 
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+
 // Forward declaration.
 class PVTW;
 


### PR DESCRIPTION
Several files stopped compiling due to relying on opm-parser headers
doing includes. From opm-parser PR-656
https://github.com/OPM/opm-parser/pull/656 this assumption is no longer
valid.