### PR TITLE
Change Deck access methods/types to references

### DIFF
--- a/examples/mimetic_aniso_solver_test.cpp
+++ b/examples/mimetic_aniso_solver_test.cpp
@@ -133,11 +133,11 @@ void build_grid(Opm::DeckConstPtr deck,
     cartDims[1] = g.dims[1] = insp.gridSize()[1];
     cartDims[2] = g.dims[2] = insp.gridSize()[2];
 
-    g.coord = &deck->getKeyword("COORD")->getSIDoubleData()[0];
-    g.zcorn = &deck->getKeyword("ZCORN")->getSIDoubleData()[0];
+    g.coord = &deck->getKeyword("COORD").getSIDoubleData()[0];
+    g.zcorn = &deck->getKeyword("ZCORN").getSIDoubleData()[0];
 
     if (deck->hasKeyword("ACTNUM")) {
-        g.actnum = &deck->getKeyword("ACTNUM")->getIntData()[0];
+        g.actnum = &deck->getKeyword("ACTNUM").getIntData()[0];
         grid.processEclipseFormat(g, z_tol, false, false);
     } else {
         std::vector<int> dflt_actnum(g.dims[0] * g.dims[1] * g.dims[2], 1);

--- a/opm/porsol/blackoil/BlackoilFluid.hpp
+++ b/opm/porsol/blackoil/BlackoilFluid.hpp
@@ -49,10 +49,10 @@ namespace Opm
             fmi_params_.init(deck);
             // FluidSystemBlackoil<>::init(parser);
             pvt_.init(deck);
-            Opm::DeckRecordConstPtr densityRecord = deck->getKeyword("DENSITY")->getRecord(0);
-            surface_densities_[Oil] = densityRecord->getItem("OIL")->getSIDouble(0);
-            surface_densities_[Water] = densityRecord->getItem("WATER")->getSIDouble(0);
-            surface_densities_[Gas] = densityRecord->getItem("GAS")->getSIDouble(0);
+            const auto& densityRecord = deck->getKeyword("DENSITY").getRecord(0);
+            surface_densities_[Oil] = densityRecord.getItem("OIL").getSIDouble(0);
+            surface_densities_[Water] = densityRecord.getItem("WATER").getSIDouble(0);
+            surface_densities_[Gas] = densityRecord.getItem("GAS").getSIDouble(0);
         }
 
         FluidState computeState(PhaseVec phase_pressure, CompVec z) const

--- a/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
+++ b/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
@@ -49,11 +49,11 @@ namespace Opm
 
 	// Surface densities. Accounting for different orders in eclipse and our code.
 	if (deck->hasKeyword("DENSITY")) {
-        Opm::DeckRecordConstPtr densityRecord =
-            deck->getKeyword("DENSITY")->getRecord(/*regionIdx=*/0);
-	    densities_[Aqua]   = densityRecord->getItem("WATER")->getSIDouble(0);
-	    densities_[Vapour] = densityRecord->getItem("GAS")->getSIDouble(0);
-	    densities_[Liquid] = densityRecord->getItem("OIL")->getSIDouble(0);
+        const auto& densityRecord =
+            deck->getKeyword("DENSITY").getRecord(/*regionIdx=*/0);
+	    densities_[Aqua]   = densityRecord.getItem("WATER").getSIDouble(0);
+	    densities_[Vapour] = densityRecord.getItem("GAS").getSIDouble(0);
+	    densities_[Liquid] = densityRecord.getItem("OIL").getSIDouble(0);
 	} else {
 	    OPM_THROW(std::runtime_error, "Input is missing DENSITY\n");
 	}

--- a/opm/porsol/blackoil/fluid/MiscibilityWater.hpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityWater.hpp
@@ -51,15 +51,15 @@ namespace Opm
     public:
         typedef std::vector<std::vector<double> > table_t;
 
-        MiscibilityWater(DeckKeywordConstPtr pvtwKeyword)
+        MiscibilityWater(const DeckKeyword& pvtwKeyword)
         {
-            auto pvtwRecord = pvtwKeyword->getRecord(0);
-            ref_press_ = pvtwRecord->getItem("P_REF")->getSIDouble(0);
-            ref_B_     = pvtwRecord->getItem("WATER_VOL_FACTOR")->getSIDouble(0);
-            comp_      = pvtwRecord->getItem("WATER_COMPRESSIBILITY")->getSIDouble(0);
-            viscosity_ = pvtwRecord->getItem("WATER_VISCOSITY")->getSIDouble(0);
+            const auto& pvtwRecord = pvtwKeyword.getRecord(0);
+            ref_press_ = pvtwRecord.getItem("P_REF").getSIDouble(0);
+            ref_B_     = pvtwRecord.getItem("WATER_VOL_FACTOR").getSIDouble(0);
+            comp_      = pvtwRecord.getItem("WATER_COMPRESSIBILITY").getSIDouble(0);
+            viscosity_ = pvtwRecord.getItem("WATER_VISCOSITY").getSIDouble(0);
 
-            if (pvtwRecord->getItem("WATER_VISCOSIBILITY")->getSIDouble(0) != 0.0) {
+            if (pvtwRecord.getItem("WATER_VISCOSIBILITY").getSIDouble(0) != 0.0) {
                 OPM_THROW(std::runtime_error, "MiscibilityWater does not support 'viscosibility'.");
             }
         }
@@ -74,14 +74,14 @@ namespace Opm
         }
 
         // WTF?? we initialize a class for water from a keyword for oil?
-        void initFromPvcdo(DeckKeywordConstPtr pvcdoKeyword)
+        void initFromPvcdo(const DeckKeyword& pvcdoKeyword)
         {
-            auto pvcdoRecord = pvcdoKeyword->getRecord(0);
-            ref_press_ = pvcdoRecord->getItem("P_REF")->getSIDouble(0);
-            ref_B_     = pvcdoRecord->getItem("OIL_VOL_FACTOR")->getSIDouble(0);
-            comp_      = pvcdoRecord->getItem("OIL_COMPRESSIBILITY")->getSIDouble(0);
-            viscosity_ = pvcdoRecord->getItem("OIL_VISCOSITY")->getSIDouble(0);
-            if (pvcdoRecord->getItem("OIL_VISCOSIBILITY")->getSIDouble(0) != 0.0) {
+            const auto& pvcdoRecord = pvcdoKeyword.getRecord(0);
+            ref_press_ = pvcdoRecord.getItem("P_REF").getSIDouble(0);
+            ref_B_     = pvcdoRecord.getItem("OIL_VOL_FACTOR").getSIDouble(0);
+            comp_      = pvcdoRecord.getItem("OIL_COMPRESSIBILITY").getSIDouble(0);
+            viscosity_ = pvcdoRecord.getItem("OIL_VISCOSITY").getSIDouble(0);
+            if (pvcdoRecord.getItem("OIL_VISCOSIBILITY").getSIDouble(0) != 0.0) {
                 OPM_THROW(std::runtime_error, "MiscibilityWater does not support 'viscosibility'.");
             }
         }

--- a/opm/porsol/common/ReservoirPropertyCommon_impl.hpp
+++ b/opm/porsol/common/ReservoirPropertyCommon_impl.hpp
@@ -194,49 +194,49 @@ namespace Opm
             // 1st row: [kxx, kxy, kxz]
             if (deck->hasKeyword("PERMX" )) {
                 kmap[xx] = tensor.size();
-                tensor.push_back(&deck->getKeyword("PERMX")->getSIDoubleData());
+                tensor.push_back(&deck->getKeyword("PERMX").getSIDoubleData());
 
                 setScalarPermIfNeeded(kmap, xx, yy, zz);
             }
             if (deck->hasKeyword("PERMXY")) {
                 kmap[xy] = kmap[yx] = tensor.size();  // Enforce symmetry.
-                tensor.push_back(&deck->getKeyword("PERMXY")->getSIDoubleData());
+                tensor.push_back(&deck->getKeyword("PERMXY").getSIDoubleData());
             }
             if (deck->hasKeyword("PERMXZ")) {
                 kmap[xz] = kmap[zx] = tensor.size();  // Enforce symmetry.
-                tensor.push_back(&deck->getKeyword("PERMXZ")->getSIDoubleData());
+                tensor.push_back(&deck->getKeyword("PERMXZ").getSIDoubleData());
             }
 
             // -----------------------------------------------------------
             // 2nd row: [kyx, kyy, kyz]
             if (deck->hasKeyword("PERMYX")) {
                 kmap[yx] = kmap[xy] = tensor.size();  // Enforce symmetry.
-                tensor.push_back(&deck->getKeyword("PERMYX")->getSIDoubleData());
+                tensor.push_back(&deck->getKeyword("PERMYX").getSIDoubleData());
             }
             if (deck->hasKeyword("PERMY" )) {
                 kmap[yy] = tensor.size();
-                tensor.push_back(&deck->getKeyword("PERMY")->getSIDoubleData());
+                tensor.push_back(&deck->getKeyword("PERMY").getSIDoubleData());
 
                 setScalarPermIfNeeded(kmap, yy, zz, xx);
             }
             if (deck->hasKeyword("PERMYZ")) {
                 kmap[yz] = kmap[zy] = tensor.size();  // Enforce symmetry.
-                tensor.push_back(&deck->getKeyword("PERMYZ")->getSIDoubleData());
+                tensor.push_back(&deck->getKeyword("PERMYZ").getSIDoubleData());
             }
 
             // -----------------------------------------------------------
             // 3rd row: [kzx, kzy, kzz]
             if (deck->hasKeyword("PERMZX")) {
                 kmap[zx] = kmap[xz] = tensor.size();  // Enforce symmetry.
-                tensor.push_back(&deck->getKeyword("PERMZX")->getSIDoubleData());
+                tensor.push_back(&deck->getKeyword("PERMZX").getSIDoubleData());
             }
             if (deck->hasKeyword("PERMZY")) {
                 kmap[zy] = kmap[yz] = tensor.size();  // Enforce symmetry.
-                tensor.push_back(&deck->getKeyword("PERMZY")->getSIDoubleData());
+                tensor.push_back(&deck->getKeyword("PERMZY").getSIDoubleData());
             }
             if (deck->hasKeyword("PERMZ" )) {
                 kmap[zz] = tensor.size();
-                tensor.push_back(&deck->getKeyword("PERMZ")->getSIDoubleData());
+                tensor.push_back(&deck->getKeyword("PERMZ").getSIDoubleData());
 
                 setScalarPermIfNeeded(kmap, zz, xx, yy);
             }
@@ -598,7 +598,7 @@ namespace Opm
             Opm::EclipseGridInspector insp(deck);
             std::array<int, 3> dims = insp.gridSize();
             int num_global_cells = dims[0]*dims[1]*dims[2];
-            const std::vector<double>& poro = deck->getKeyword("PORO")->getSIDoubleData();
+            const std::vector<double>& poro = deck->getKeyword("PORO").getSIDoubleData();
             if (int(poro.size()) != num_global_cells) {
                 OPM_THROW(std::runtime_error, "PORO field must have the same size as the "
                       "logical cartesian size of the grid: "
@@ -620,7 +620,7 @@ namespace Opm
             Opm::EclipseGridInspector insp(deck);
             std::array<int, 3> dims = insp.gridSize();
             int num_global_cells = dims[0]*dims[1]*dims[2];
-            const std::vector<double>& ntg = deck->getKeyword("NTG")->getSIDoubleData();
+            const std::vector<double>& ntg = deck->getKeyword("NTG").getSIDoubleData();
             if (int(ntg.size()) != num_global_cells) {
                 OPM_THROW(std::runtime_error, "NTG field must have the same size as the "
                       "logical cartesian size of the grid: "
@@ -643,7 +643,7 @@ namespace Opm
             std::array<int, 3> dims = insp.gridSize();
             int num_global_cells = dims[0]*dims[1]*dims[2];
             const std::vector<double>& swcr =
-                deck->getKeyword("SWCR")->getSIDoubleData();
+                deck->getKeyword("SWCR").getSIDoubleData();
             if (int(swcr.size()) != num_global_cells) {
                 OPM_THROW(std::runtime_error, "SWCR field must have the same size as the "
                       "logical cartesian size of the grid: "
@@ -666,7 +666,7 @@ namespace Opm
             std::array<int, 3> dims = insp.gridSize();
             int num_global_cells = dims[0]*dims[1]*dims[2];
             const std::vector<double>& sowcr =
-                deck->getKeyword("SOWCR")->getSIDoubleData();
+                deck->getKeyword("SOWCR").getSIDoubleData();
             if (int(sowcr.size()) != num_global_cells) {
                 OPM_THROW(std::runtime_error, "SOWCR field must have the same size as the "
                       "logical cartesian size of the grid: "
@@ -750,7 +750,7 @@ namespace Opm
             Opm::EclipseGridInspector insp(deck);
             std::array<int, 3> dims = insp.gridSize();
             int num_global_cells = dims[0]*dims[1]*dims[2];
-            const std::vector<int>& satnum = deck->getKeyword("SATNUM")->getIntData();
+            const std::vector<int>& satnum = deck->getKeyword("SATNUM").getIntData();
             if (int(satnum.size()) != num_global_cells) {
                 OPM_THROW(std::runtime_error, "SATNUM field must have the same size as the "
                       "logical cartesian size of the grid: "
@@ -765,7 +765,7 @@ namespace Opm
             Opm::EclipseGridInspector insp(deck);
             std::array<int, 3> dims = insp.gridSize();
             int num_global_cells = dims[0]*dims[1]*dims[2];
-            const std::vector<int>& satnum = deck->getKeyword("ROCKTYPE")->getIntData();
+            const std::vector<int>& satnum = deck->getKeyword("ROCKTYPE").getIntData();
             if (int(satnum.size()) != num_global_cells) {
                 OPM_THROW(std::runtime_error, "ROCKTYPE field must have the same size as the "
                       "logical cartesian size of the grid: "

--- a/opm/porsol/common/Rock_impl.hpp
+++ b/opm/porsol/common/Rock_impl.hpp
@@ -118,7 +118,7 @@ namespace Opm
         porosity_.assign(global_cell.size(), 1.0);
 
         if (deck->hasKeyword("PORO")) {
-            const std::vector<double>& poro = deck->getKeyword("PORO")->getSIDoubleData();
+            const std::vector<double>& poro = deck->getKeyword("PORO").getSIDoubleData();
 
             for (int c = 0; c < int(porosity_.size()); ++c) {
                 porosity_[c] = poro[global_cell[c]];


### PR DESCRIPTION
opm-parser#677 changes the return types for the Deck family of classes.
This patch fixes all broken code from that patch set.

https://github.com/OPM/opm-parser/pull/677